### PR TITLE
New Output: Elastic ES|QL

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,12 @@ name: Test Build
 on:
   push:
     branches:
-      - '**'  # This will match any branch
+      - '**'
     tags:
-      - '*'  # This will match any tag
+      - '*'
+  pull_request:
+    paths:
+      - 'src/**'
 
 jobs:
   test_build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
       - 'src/**'
 
 jobs:
-  test_build:
+  run_tests:
     runs-on: ubuntu-latest
 
     container:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,5 @@ azure-monitor-query==1.3.0
 splunk-sdk==2.0.1
 colorama==0.4.6
 python-json-logger==2.0.7
-requests>=2.32.3
-elasticsearch
+requests==2.32.3
+elasticsearch==8.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ splunk-sdk==2.0.1
 colorama==0.4.6
 python-json-logger==2.0.7
 requests>=2.32.3
+elasticsearch

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ azure-monitor-query==1.3.0
 splunk-sdk==2.0.1
 colorama==0.4.6
 python-json-logger==2.0.7
+requests>=2.32.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     colorama==0.4.6
     python-json-logger==2.0.7
     elasticsearch==8.14.0
+    requests==2.32.3
 
 [options.packages.find]
 where=src

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ install_requires =
     splunk-sdk==2.0.1
     colorama==0.4.6
     python-json-logger==2.0.7
+    elasticsearch==8.14.0
 
 [options.packages.find]
 where=src

--- a/src/droid/__main__.py
+++ b/src/droid/__main__.py
@@ -232,7 +232,7 @@ def droid_platform_config(args, config_path):
             with open(config_path) as file_obj:
                 content = file_obj.read()
                 config_data = tomllib.loads(content)
-                config_elastic = config_data["platforms"][args.platform]
+                config_elastic = config_data["platforms"]["elastic"]
         except Exception as e:
             raise Exception(f"Something unexpected happened: {e}")
 
@@ -384,7 +384,8 @@ def main(argv=None) -> None:
             logger.error("Export mode for MDE is only available via Azure Sentinel backend for now.")
             exit(1)
 
-        elif args.platform == 'esql':
+        elif args.platform == 'esql' or args.platform == 'eql':
+            args.platform == 'elastic'
             if is_raw_rule(args, base_config):
                 logger.info("Elastic Security raw rule selected")
                 platform_config = droid_platform_config(args, config_path)
@@ -392,12 +393,6 @@ def main(argv=None) -> None:
             else:
                 platform_config = droid_platform_config(args, config_path)
                 export_error = convert_rules(parameters, platform_config, base_config)
-        elif args.platform == 'eql':
-            if is_raw_rule(args, base_config):
-                logger.info("Elastic Security raw rule selected")
-                export_error = export_rule_raw(parameters, droid_platform_config(args, config_path))
-            else:
-                export_error = convert_rules(parameters, droid_platform_config(args, config_path))
 
         else:
             logger.error("Please select one platform. See option -p in --help")

--- a/src/droid/__main__.py
+++ b/src/droid/__main__.py
@@ -82,16 +82,15 @@ def is_raw_rule(args, base_config):
             exit(1)
     else:
         return False
-
     if (
-        (args.platform in ['splunk', 'azure'] or
+        (args.platform in ['splunk', 'azure', 'esql', 'eql'] or
         (args.platform == 'microsoft_defender' and args.sentinel_mde)) and
         (raw_rule_folder_name in args.rules and args.platform in args.rules)
     ):
         return True
 
     elif (
-        args.platform in ['splunk', 'azure'] or
+        args.platform in ['splunk', 'azure', 'esql'] or
         (args.platform == 'microsoft_defender' and args.sentinel_mde)
     ):
         return False

--- a/src/droid/__main__.py
+++ b/src/droid/__main__.py
@@ -39,7 +39,7 @@ def init_argparse() -> argparse.ArgumentParser:
     parser.add_argument("-cf", "--config-file", help="DROID configuration file path")
     parser.add_argument("-d", "--debug", help="Enable debugging", action="store_true")
     parser.add_argument("-e", "--export", help="Export the rules", action="store_true")
-    parser.add_argument("-p", "--platform", help="Platform target", choices=['splunk', 'azure', 'microsoft_defender', 'elastic-esql', 'elastic-eql'])
+    parser.add_argument("-p", "--platform", help="Platform target", choices=['splunk', 'azure', 'microsoft_defender', 'esql', 'eql'])
     parser.add_argument("-sm", "--sentinel-mde", help="Use Sentinel as backend for MDE", action="store_true")
     parser.add_argument("-u", "--update", help="Update from source", choices=['sigmahq-core'])
     parser.add_argument("-l", "--list", help="List items from rules", choices=['unique_fields', 'pipelines'])

--- a/src/droid/__main__.py
+++ b/src/droid/__main__.py
@@ -155,7 +155,7 @@ def droid_platform_config(args, config_path):
 
         return config_splunk
 
-    if args.platform == 'azure' or args.platform == 'defender':
+    if args.platform == 'azure' or args.platform == 'microsoft_defender':
         try:
             with open(config_path) as file_obj:
                 content = file_obj.read()

--- a/src/droid/__main__.py
+++ b/src/droid/__main__.py
@@ -267,9 +267,6 @@ def main(argv=None) -> None:
         raise Exception(f"Error: configuration file {args.config_file} not found.")
     else:
         config_path = args.config_file
-    # Check if platform is elastic and remove the prefix since the backends are called esql and eql
-    if args.platform.startswith("elastic-"):
-        args.platform = args.platform.replace("elastic-", "")
     if args.validate:
 
         logger.info(f"Validation mode was selected - path selected: {args.rules}")

--- a/src/droid/__main__.py
+++ b/src/droid/__main__.py
@@ -83,14 +83,15 @@ def is_raw_rule(args, base_config):
     else:
         return False
     if (
-        (args.platform in ['splunk', 'azure', 'esql', 'eql'] or
+        (args.platform in ['splunk', 'azure'] or
         (args.platform == 'microsoft_defender' and args.sentinel_mde)) and
         (raw_rule_folder_name in args.rules and args.platform in args.rules)
     ):
         return True
-
+    elif args.platform == 'esql' and raw_rule_folder_name in args.rules:
+        return True
     elif (
-        args.platform in ['splunk', 'azure', 'esql'] or
+        args.platform in ['splunk', 'azure'] or
         (args.platform == 'microsoft_defender' and args.sentinel_mde)
     ):
         return False

--- a/src/droid/__main__.py
+++ b/src/droid/__main__.py
@@ -226,7 +226,7 @@ def droid_platform_config(args, config_path):
 
         return config
 
-    if args.platform == 'esql':
+    if args.platform in ['esql', 'eql']:
 
         try:
             with open(config_path) as file_obj:

--- a/src/droid/__main__.py
+++ b/src/droid/__main__.py
@@ -335,7 +335,7 @@ def main(argv=None) -> None:
             search_error, search_warning = search_rule_raw(parameters, droid_platform_config(args, config_path))
         else:
             logger.info(f"Searching Sigma rule for platform {args.platform} selected")
-            search_error, search_warning = convert_rules(parameters, droid_platform_config(args, config_path))
+            search_error, search_warning = convert_rules(parameters, droid_platform_config(args, config_path), base_config)
 
         if search_error and search_warning:
             logger.warning("Hits found while search one or multiple rules")
@@ -371,14 +371,14 @@ def main(argv=None) -> None:
                 logger.info("Azure Sentinel raw rule selected")
                 export_error = export_rule_raw(parameters, droid_platform_config(args, config_path))
             else:
-                export_error = convert_rules(parameters, droid_platform_config(args, config_path))
+                export_error = convert_rules(parameters, droid_platform_config(args, config_path), base_config)
 
         elif args.platform == 'microsoft_defender' and args.sentinel_mde:
             if is_raw_rule(args, base_config):
                 logger.info("Microsoft Defender for Endpoint raw rule selected")
                 export_error = export_rule_raw(parameters, droid_platform_config(args, config_path))
             else:
-                export_error = convert_rules(parameters, droid_platform_config(args, config_path))
+                export_error = convert_rules(parameters, droid_platform_config(args, config_path), base_config)
 
         elif args.platform == "microsoft_defender" and not args.sentinel_mde:
             logger.error("Export mode for MDE is only available via Azure Sentinel backend for now.")
@@ -388,11 +388,9 @@ def main(argv=None) -> None:
             args.platform == 'elastic'
             if is_raw_rule(args, base_config):
                 logger.info("Elastic Security raw rule selected")
-                platform_config = droid_platform_config(args, config_path)
-                export_error = export_rule_raw(parameters, platform_config)
+                export_error = export_rule_raw(parameters, droid_platform_config(args, config_path))
             else:
-                platform_config = droid_platform_config(args, config_path)
-                export_error = convert_rules(parameters, platform_config, base_config)
+                export_error = convert_rules(parameters, droid_platform_config(args, config_path), base_config)
 
         else:
             logger.error("Please select one platform. See option -p in --help")
@@ -426,7 +424,7 @@ def main(argv=None) -> None:
             integrity_error = integrity_rule_raw(parameters, droid_platform_config(args, config_path))
         else:
             logger.info(f"Integrity check for platform {args.platform} selected")
-            integrity_error = convert_rules(parameters, droid_platform_config(args, config_path))
+            integrity_error = convert_rules(parameters, droid_platform_config(args, config_path), base_config)
 
         if integrity_error:
             logger.error("Integrity error")

--- a/src/droid/abstracts.py
+++ b/src/droid/abstracts.py
@@ -1,0 +1,28 @@
+from abc import ABC, abstractmethod
+
+
+class AbstractPlatform(ABC):
+    """
+    AbstractRule is an abstract base class that defines the structure for a platform.
+    It has three abstract methods: create_rule, remove_rule
+    """
+
+    def __init__(self, name: str):
+        """
+        Initialize the platform.
+        """
+        self.platform_name = name
+
+    @abstractmethod
+    def create_rule(self):
+        """
+        Create a detection rule. This method should be implemented by subclasses.
+        """
+        raise NotImplemented()
+
+    @abstractmethod
+    def remove_rule(self):
+        """
+        Remove a rule. This method should be implemented by subclasses.
+        """
+        raise NotImplemented()

--- a/src/droid/abstracts.py
+++ b/src/droid/abstracts.py
@@ -21,6 +21,13 @@ class AbstractPlatform(ABC):
         raise NotImplemented()
 
     @abstractmethod
+    def get_rule(self):
+        """
+        Get the parameter from a rule. This method should be implemented by subclasses.
+        """
+        raise NotImplemented()
+
+    @abstractmethod
     def remove_rule(self):
         """
         Remove a rule. This method should be implemented by subclasses.

--- a/src/droid/convert.py
+++ b/src/droid/convert.py
@@ -182,6 +182,8 @@ def convert_rules(parameters, droid_config, base_config):
             platform = SplunkPlatform(droid_config, parameters.debug, parameters.json)
         elif 'esql' in platform_name:
             platform = ElasticPlatform(droid_config, parameters.debug, parameters.json)
+        elif 'eql' in platform_name:
+            platform = ElasticPlatform(droid_config, parameters.debug, parameters.json)
         elif 'azure' or 'defender' in platform_name:
             platform = SentinelPlatform(droid_config, parameters.debug, parameters.json)
 

--- a/src/droid/convert.py
+++ b/src/droid/convert.py
@@ -248,7 +248,10 @@ def convert_sigma(parameters, logger, rule_content, rule_file, target, platform,
         logger.error(f"Sigma Transformation error: {rule_file} - error: {e}", extra={"rule_file": rule_file, "error": e, "rule_content": rule_content})
         error = True
         return error, search_warning
-
+    except NotImplementedError as e:
+        logger.error(f"Sigma Transformation error: {rule_file} - error: {e}", extra={"rule_file": rule_file, "error": e, "rule_content": rule_content})
+        error = True
+        return error, search_warning
     except Exception as e:
             logger.error(f"Fatal error when compiling the rule {rule_file} - verify the backend {e} is installed")
             error = True

--- a/src/droid/convert.py
+++ b/src/droid/convert.py
@@ -129,7 +129,6 @@ class Conversion:
             return rule_converted
         else:
             self.logger.warning(f"Rule not supported: {rule_file}", extra={"rule_file": rule_file, "rule_content": rule_content})
-            return None, None # Return None, None if the rule is not supported otherwise python will throw an error
 
 def load_rule(rule_file):
 

--- a/src/droid/convert.py
+++ b/src/droid/convert.py
@@ -124,7 +124,7 @@ class Conversion:
             rule_converted = backend.convert(sigma_rule, self._format)[0]
             # For esql and eql backend only
             if isinstance(platform, ElasticPlatform):
-                platform.get_index_name(pipeline)
+                platform.get_index_name(pipeline, rule_content)
             self.logger.info(f"Successfully convert the rule {rule_file}", extra={"rule_file": rule_file, "rule_content": rule_content, "rule_format": self._format, "rule_converted": rule_converted})
             return rule_converted
         else:

--- a/src/droid/convert.py
+++ b/src/droid/convert.py
@@ -81,7 +81,7 @@ class Conversion:
         Args:
             rule
         """
-        with open(rule_file, "r") as file:
+        with open(rule_file, "r", encoding="utf-8") as file:
             if self._filters_directory:
                 sigma_rule = self.init_sigma_filters(rule_file)
             else:
@@ -139,7 +139,7 @@ class Conversion:
 
 def load_rule(rule_file):
 
-    with open(rule_file, 'r') as stream:
+    with open(rule_file, 'r', encoding="utf-8") as stream:
         try:
             object = list(yaml.safe_load_all(stream))[0]
             if 'fields' in object:

--- a/src/droid/convert.py
+++ b/src/droid/convert.py
@@ -181,9 +181,9 @@ def convert_rules(parameters, droid_config, base_config):
         if platform_name == 'splunk':
             platform = SplunkPlatform(droid_config, parameters.debug, parameters.json)
         elif 'esql' in platform_name:
-            platform = ElasticPlatform(droid_config, parameters.debug, parameters.json)
+            platform = ElasticPlatform(droid_config, parameters.debug, parameters.json, "esql")
         elif 'eql' in platform_name:
-            platform = ElasticPlatform(droid_config, parameters.debug, parameters.json)
+            platform = ElasticPlatform(droid_config, parameters.debug, parameters.json, "eql")
         elif 'azure' or 'defender' in platform_name:
             platform = SentinelPlatform(droid_config, parameters.debug, parameters.json)
 

--- a/src/droid/convert.py
+++ b/src/droid/convert.py
@@ -13,6 +13,7 @@ from droid.export import export_rule
 from droid.integrity import integrity_rule
 from droid.platforms.splunk import SplunkPlatform
 from droid.platforms.sentinel import SentinelPlatform
+from droid.platforms.elastic import ElasticPlatform
 from droid.color import ColorLogger
 
 class Conversion:
@@ -179,6 +180,8 @@ def convert_rules(parameters, droid_config, base_config):
         target = Conversion(droid_config, base_config, platform_name, parameters.debug, parameters.json)
         if platform_name == 'splunk':
             platform = SplunkPlatform(droid_config, parameters.debug, parameters.json)
+        elif 'esql' in platform_name:
+            platform = ElasticPlatform(droid_config, parameters.debug, parameters.json)
         elif 'azure' or 'defender' in platform_name:
             platform = SentinelPlatform(droid_config, parameters.debug, parameters.json)
 

--- a/src/droid/convert.py
+++ b/src/droid/convert.py
@@ -184,9 +184,9 @@ def convert_rules(parameters, droid_config, base_config):
         if platform_name == 'splunk':
             platform = SplunkPlatform(droid_config, parameters.debug, parameters.json)
         elif 'esql' in platform_name:
-            platform = ElasticPlatform(droid_config, parameters.debug, parameters.json, "esql")
+            platform = ElasticPlatform(droid_config, parameters.debug, parameters.json, "esql", raw=False)
         elif 'eql' in platform_name:
-            platform = ElasticPlatform(droid_config, parameters.debug, parameters.json, "eql")
+            platform = ElasticPlatform(droid_config, parameters.debug, parameters.json, "eql", raw=False)
         elif 'azure' or 'defender' in platform_name:
             platform = SentinelPlatform(droid_config, parameters.debug, parameters.json)
 

--- a/src/droid/convert.py
+++ b/src/droid/convert.py
@@ -123,18 +123,19 @@ class Conversion:
             sigma_rule = self.init_sigma_rule(rule_file)
             rule_converted = backend.convert(sigma_rule, self._format)[0]
             # For esql and eql backend, we grab the value of the transformation state with the key index
+            index_value = None
             if isinstance(platform, ElasticPlatform):
                 for item in pipeline.items:
-                    if item.transformation.key == 'index':
-                        index_value = item.transformation.val
-                        self.logger.info(f"The value of the key 'index' is: {index_value}")
-                        break
-            else:
-                index_value = None
+                    if hasattr(item, 'transformation') and hasattr(item.transformation, 'key') and hasattr(item.transformation, 'val'):
+                        if item.transformation.key == 'index':
+                            index_value = item.transformation.val
+                            self.logger.info(f"The value of the key 'index' is: {index_value}")
+                            break
             self.logger.info(f"Successfully convert the rule {rule_file}", extra={"rule_file": rule_file, "rule_content": rule_content, "rule_format": self._format, "rule_converted": rule_converted})
             return rule_converted, index_value
         else:
             self.logger.warning(f"Rule not supported: {rule_file}", extra={"rule_file": rule_file, "rule_content": rule_content})
+            return None, None # Return None, None if the rule is not supported otherwise python will throw an error
 
 def load_rule(rule_file):
 

--- a/src/droid/export.py
+++ b/src/droid/export.py
@@ -37,7 +37,10 @@ def load_rule(rule_file):
             error = True
             return error
 
-def export_rule(parameters: dict, rule_content: object, rule_converted: str, platform: object, rule_file: str, error: bool):
+def export_rule(
+        parameters: dict, rule_content: object, rule_converted: str,
+        platform: object, rule_file: str, error: bool, index_name: str | None):
+
     logger = ColorLogger("droid.export")
 
     rule_content = post_rule_content(rule_content)

--- a/src/droid/export.py
+++ b/src/droid/export.py
@@ -74,9 +74,9 @@ def export_rule_raw(parameters: dict, export_config: dict):
     elif parameters.platform == 'microsoft_defender' and parameters.sentinel_mde:
         platform = SentinelPlatform(export_config, parameters.debug, parameters.json)
     elif parameters.platform == 'esql':
-        platform = ElasticPlatform(export_config, parameters.debug, parameters.json, "esql")
+        platform = ElasticPlatform(export_config, parameters.debug, parameters.json, "esql", raw=True)
     elif parameters.platform == 'eql':
-        platform = ElasticPlatform(export_config, parameters.debug, parameters.json, "eql")
+        platform = ElasticPlatform(export_config, parameters.debug, parameters.json, "eql", raw=True)
 
     if path.is_dir():
         error_i = False

--- a/src/droid/export.py
+++ b/src/droid/export.py
@@ -39,7 +39,7 @@ def load_rule(rule_file):
 
 def export_rule(
         parameters: dict, rule_content: object, rule_converted: str,
-        platform: object, rule_file: str, error: bool, index_name: str | None):
+        platform: object, rule_file: str, error: bool):
 
     logger = ColorLogger("droid.export")
 
@@ -49,9 +49,9 @@ def export_rule(
         logger.enable_json_logging()
     try:
         if rule_content.get('custom', {}).get('removed', False): # If rule is set as removed
-            platform.remove_search(rule_content, rule_converted, rule_file)
+            platform.remove_rule(rule_content, rule_converted, rule_file)
         else:
-            platform.create_search(rule_content, rule_converted, rule_file, index_name)
+            platform.create_rule(rule_content, rule_converted, rule_file)
     except Exception as e:
         logger.error(f"Could not export the rule {rule_file}: {e}")
         error = True
@@ -86,13 +86,13 @@ def export_rule_raw(parameters: dict, export_config: dict):
             rule_converted = rule_content['detection']
             if rule_content.get('custom', {}).get('removed', False): # If rule is set as removed
                 try:
-                    platform.remove_search(rule_content, rule_converted, rule_file)
+                    platform.remove_rule(rule_content, rule_converted, rule_file)
                 except:
                     logger.error(f"Error in removing search for rule {rule_file}")
                     error_i = True
             else:
                 try:
-                    platform.create_search(rule_content, rule_converted, rule_file)
+                    platform.create_rule(rule_content, rule_converted, rule_file)
                 except:
                     logger.error(f"Error in creating search for rule {rule_file}")
                     error_i = True
@@ -107,13 +107,13 @@ def export_rule_raw(parameters: dict, export_config: dict):
         rule_converted = rule_content['detection']
         if rule_content.get('custom', {}).get('removed', False): # If rule is set as removed
             try:
-                platform.remove_search(rule_content, rule_converted, rule_file)
+                platform.remove_rule(rule_content, rule_converted, rule_file)
             except:
                 logger.error(f"Error in removing search for rule {rule_file}")
                 error = True
         else:
             try:
-                platform.create_search(rule_content, rule_converted, rule_file)
+                platform.create_rule(rule_content, rule_converted, rule_file)
             except:
                 logger.error(f"Error in creating search for rule {rule_file}")
                 error = True

--- a/src/droid/export.py
+++ b/src/droid/export.py
@@ -71,9 +71,9 @@ def export_rule_raw(parameters: dict, export_config: dict):
     elif parameters.platform == 'microsoft_defender' and parameters.sentinel_mde:
         platform = SentinelPlatform(export_config, parameters.debug, parameters.json)
     elif parameters.platform == 'esql':
-        platform = ElasticPlatform(export_config, parameters.debug, parameters.json)
+        platform = ElasticPlatform(export_config, parameters.debug, parameters.json, "esql")
     elif parameters.platform == 'eql':
-        platform = ElasticPlatform(export_config, parameters.debug, parameters.json)
+        platform = ElasticPlatform(export_config, parameters.debug, parameters.json, "eql")
 
     if path.is_dir():
         error_i = False

--- a/src/droid/export.py
+++ b/src/droid/export.py
@@ -72,6 +72,8 @@ def export_rule_raw(parameters: dict, export_config: dict):
         platform = SentinelPlatform(export_config, parameters.debug, parameters.json)
     elif parameters.platform == 'esql':
         platform = ElasticPlatform(export_config, parameters.debug, parameters.json)
+    elif parameters.platform == 'eql':
+        platform = ElasticPlatform(export_config, parameters.debug, parameters.json)
 
     if path.is_dir():
         error_i = False

--- a/src/droid/export.py
+++ b/src/droid/export.py
@@ -7,6 +7,7 @@ from os import environ
 from pathlib import Path
 from droid.platforms.splunk import SplunkPlatform
 from droid.platforms.sentinel import SentinelPlatform
+from droid.platforms.elastic import ElasticPlatform
 from droid.color import ColorLogger
 
 def post_rule_content(rule_content):
@@ -69,6 +70,8 @@ def export_rule_raw(parameters: dict, export_config: dict):
         platform = SentinelPlatform(export_config, parameters.debug, parameters.json)
     elif parameters.platform == 'microsoft_defender' and parameters.sentinel_mde:
         platform = SentinelPlatform(export_config, parameters.debug, parameters.json)
+    elif parameters.platform == 'esql':
+        platform = ElasticPlatform(export_config, parameters.debug, parameters.json)
 
     if path.is_dir():
         error_i = False

--- a/src/droid/export.py
+++ b/src/droid/export.py
@@ -51,7 +51,7 @@ def export_rule(
         if rule_content.get('custom', {}).get('removed', False): # If rule is set as removed
             platform.remove_search(rule_content, rule_converted, rule_file)
         else:
-            platform.create_search(rule_content, rule_converted, rule_file)
+            platform.create_search(rule_content, rule_converted, rule_file, index_name)
     except Exception as e:
         logger.error(f"Could not export the rule {rule_file}: {e}")
         error = True

--- a/src/droid/integrity.py
+++ b/src/droid/integrity.py
@@ -6,6 +6,7 @@ import yaml
 from pathlib import Path
 from droid.platforms.splunk import SplunkPlatform
 from droid.platforms.sentinel import SentinelPlatform
+from droid.platforms.elastic import ElasticPlatform
 from droid.color import ColorLogger
 from droid.export import post_rule_content
 
@@ -140,6 +141,67 @@ def integrity_rule_sentinel(rule_converted, rule_content, platform: SentinelPlat
     if error:
         return error
 
+
+def integrity_rule_elastic(rule_converted, rule_content, platform: ElasticPlatform, rule_file, parameters, logger, error):
+    try:
+        saved_search: dict = platform.get_search(rule_content["id"])
+    except Exception as e:
+        logger.error(f"Couldn't check the integrity for the rule {rule_file} - error {e}")
+        return error
+
+    if saved_search:
+        logger.info(f"Successfully retrieved the rule {rule_file}")
+    else:
+        logger.error(f"Rule not found {rule_file}")
+        error = True
+        return error
+
+    result = {
+        "name": saved_search["name"],
+        "description": saved_search["description"],
+        "query": saved_search["query"]
+    }
+
+    rule_content["detection"] = rule_converted
+    mapping = {
+        #"id": "name", # Not sure why this is here?
+        "detection": "query",
+        "description": "description"
+    }
+    for key in mapping:
+
+        rule_key = key
+        result_key = mapping[key]
+
+        if rule_content.get(rule_key) == result.get(result_key):
+            if parameters.debug:
+                logger.debug(f"{rule_key} in rule_content matches {result_key} in result")
+        else:
+            logger.error(f"{rule_key} in rule_content does not match {result_key} in result")
+            error = True
+
+    # Check if disabled
+    if "custom" in rule_content and "disabled" in rule_content["custom"]:
+        is_disabled = rule_content["custom"]["disabled"]
+    else:
+        is_disabled = False
+
+    if is_disabled and not rule_content["enabled"]:
+        logger.info("The rule is disabled as expected")
+    elif is_disabled and rule_content["enabled"]:
+        logger.error("The rule is not disabled on the platform")
+        error = True
+    elif is_disabled is None and not rule_content["enabled"]:
+        logger.error("The rule is not enabled on the platform")
+        error = True
+    elif is_disabled is None and rule_content["enabled"]:
+        logger.info("The rule is enabled as expected")
+
+    if error:
+        return error
+
+
+
 def integrity_rule(parameters, rule_converted, rule_content, platform, rule_file, error):
 
     logger = ColorLogger("droid.integrity")
@@ -154,7 +216,9 @@ def integrity_rule(parameters, rule_converted, rule_content, platform, rule_file
     if parameters.platform == 'splunk':
         error = integrity_rule_splunk(rule_converted, rule_content, platform, rule_file, parameters, logger, error)
         return error
-
+    elif parameters.platform in ["esql", "eql"]:
+        error = integrity_rule_elastic(rule_converted, rule_content, platform, rule_file, parameters, logger, error)
+        return error
     elif 'azure' or 'defender' in parameters.platform:
         error = integrity_rule_sentinel(rule_converted, rule_content, platform, rule_file, parameters, logger, error)
         return error

--- a/src/droid/integrity.py
+++ b/src/droid/integrity.py
@@ -86,7 +86,7 @@ def integrity_rule_splunk(rule_converted, rule_content, platform: SplunkPlatform
 def integrity_rule_sentinel(rule_converted, rule_content, platform: SentinelPlatform, rule_file, parameters, logger, error):
 
     try:
-        saved_search: dict = platform.get_search(rule_content, rule_file)
+        saved_search: dict = platform.get_rule(rule_content, rule_file)
     # Mapping rule_content with a MS Sentinel saved search properties
         mapping = {
             "id": "name",
@@ -144,7 +144,7 @@ def integrity_rule_sentinel(rule_converted, rule_content, platform: SentinelPlat
 
 def integrity_rule_elastic(rule_converted, rule_content, platform: ElasticPlatform, rule_file, parameters, logger, error):
     try:
-        saved_search: dict = platform.get_search(rule_content["id"])
+        saved_search: dict = platform.get_rule(rule_content["id"])
     except Exception as e:
         logger.error(f"Couldn't check the integrity for the rule {rule_file} - error {e}")
         return error
@@ -156,6 +156,9 @@ def integrity_rule_elastic(rule_converted, rule_content, platform: ElasticPlatfo
         error = True
         return error
 
+    if "metadata _id, _index, _version" not in rule_converted.lower() and "metadata _id, _index, _version" in saved_search["query"].lower():
+        saved_search["query"] = saved_search["query"].replace('  METADATA _id, _index, _version', '')
+
     result = {
         "name": saved_search["name"],
         "description": saved_search["description"],
@@ -163,6 +166,7 @@ def integrity_rule_elastic(rule_converted, rule_content, platform: ElasticPlatfo
     }
 
     rule_content["detection"] = rule_converted
+
     mapping = {
         #"id": "name", # Not sure why this is here?
         "detection": "query",

--- a/src/droid/platforms/elastic.py
+++ b/src/droid/platforms/elastic.py
@@ -237,11 +237,11 @@ class ElasticPlatform(ElasticBase):
             "id": rule_content["id"],
             "name": display_name,
             "enabled": True,
-            "interval": "1h",  # TODO: Use Parameter for this value
+            "interval": f"{self._schedule_interval}{self._schedule_interval_unit}",
             "author": author,
             "description": rule_content["description"],
             "rule_id": rule_content["id"],
-            "from": "now-65m",  # TODO: Use Parameter for this value
+            "from": f"now-{self._schedule_interval}{self._schedule_interval_unit}", # TODO: This should actually always be slightly more than the interval, either make it a parameter or calculate it.
             "immutable": False,
             "license": "DRL",  # TODO: Use Parameter for this value
             "output_index": "",  # TODO: Check if there should be a parameter for this

--- a/src/droid/platforms/elastic.py
+++ b/src/droid/platforms/elastic.py
@@ -232,7 +232,11 @@ class ElasticPlatform(ElasticBase):
             self.logger.info(f"Successfully disabled the rule {rule_file}")
         else:
             enabled = True
-
+        
+        if "custom" in rule_content and "raw_language" in rule_content["custom"]:
+            language = rule_content["custom"]["raw_language"]
+        else: 
+            language = "esql"
         ndjson = {
             "id": rule_content["id"],
             "name": display_name,
@@ -259,8 +263,8 @@ class ElasticPlatform(ElasticBase):
             "related_integrations": [],
             "required_fields": [],
             "setup": "",
-            "type": "esql",
-            "language": "esql",
+            "type": language,
+            "language": language,
             "index": None,
             "query": rule_converted,
             "filters": [],

--- a/src/droid/platforms/elastic.py
+++ b/src/droid/platforms/elastic.py
@@ -73,7 +73,7 @@ class ElasticPlatform(AbstractPlatform):
 
         if "eql_search_range_gte" not in self._parameters:
             logger.debug(
-                "ElasticPlatform: 'eql_search_range_gte' is not set, using default of 1h."
+                "ElasticPlatform: 'eql_search_range_gte' is not set, using default of 24h."
             )
             self._parameters["eql_search_range_gte"] = "now-24h"
         if "esql_search_range_gte" not in self._parameters:

--- a/src/droid/platforms/elastic.py
+++ b/src/droid/platforms/elastic.py
@@ -211,6 +211,17 @@ class ElasticPlatform(AbstractPlatform):
         index_value = "logs-*"
         index_found = False
         if "logsource" in rule_content:
+            matchlist = [
+                                    "category",
+                                    "custom_attributes",
+                                    "product",
+                                    "service",
+                                    "source",
+                                ]
+            matchlength = 0
+            for x in rule_content["logsource"]:
+                if x not in matchlist:
+                    matchlength += 1
             for item in pipeline.items:
                 if (
                     hasattr(item, "transformation")
@@ -223,16 +234,10 @@ class ElasticPlatform(AbstractPlatform):
                             rule_condition
                         ) in item.transformation.processing_item.rule_conditions:
                             for key, value in rule_content["logsource"].items():
-                                if key in [
-                                    "category",
-                                    "custom_attributes",
-                                    "product",
-                                    "service",
-                                    "source",
-                                ]:
+                                if key in matchlist:
                                     if rule_condition.logsource.__dict__[key] == value:
                                         matches += 1
-                        if matches == len(rule_content["logsource"]):
+                        if matches == matchlength:
                             index_value = item.transformation.val
                             self.logger.info(
                                 f"The value of the key 'index' is: {index_value}"

--- a/src/droid/platforms/elastic.py
+++ b/src/droid/platforms/elastic.py
@@ -76,6 +76,8 @@ class ElasticPlatform(AbstractPlatform):
         if self._json:
             self.logger.enable_json_logging()
 
+        self._eql_search_range_gte = self._parameters["eql_search_range_gte"]
+        self._esql_search_range_gte = self._parameters["esql_search_range_gte"]
         self._schedule_interval = self._parameters["schedule_interval"]
         self._schedule_interval_unit = self._parameters["schedule_interval_unit"]
         self._license = self._parameters["license"]
@@ -428,7 +430,7 @@ class ElasticPlatform(AbstractPlatform):
             query=query,
             wait_for_completion_timeout=0,
             size=100,
-            filter={"range": {"@timestamp": {"gte": "now-1h"}}},
+            filter={"range": {"@timestamp": {"gte": self._eql_search_range_gte}}},
         )
         search_id = response["id"]
         es_client.eql.get_status(id=search_id)
@@ -447,7 +449,7 @@ class ElasticPlatform(AbstractPlatform):
     def run_esql_search(self, query, es_client=None):
         response = es_client.esql.query(
             query=query,
-            filter={"range": {"@timestamp": {"gte": "now-24h"}}},
+            filter={"range": {"@timestamp": {"gte": self._esql_search_range_gte}}},
         )
         if "values" in response:
             return len(response["values"])

--- a/src/droid/platforms/elastic.py
+++ b/src/droid/platforms/elastic.py
@@ -1,0 +1,281 @@
+"""
+Module for Elastic Security
+"""
+
+from droid.color import ColorLogger
+import io
+import json
+from pprint import pprint
+import requests
+from requests.auth import HTTPBasicAuth
+from sigma.data.mitre_attack import (
+    mitre_attack_techniques,
+    mitre_attack_techniques_tactics_mapping,
+    mitre_attack_tactics,
+)
+import os
+
+logger = ColorLogger("droid.platforms.sentinel")
+
+
+class ElasticBase:
+    """Sentinel base class
+
+    Base class for importing datasource/product data
+    """
+
+    def __init__(self, parameters: dict) -> None:
+        self.logger = ColorLogger("droid.platforms.sentinel.ElasticBase")
+        self._parameters = parameters
+
+
+class ElasticPlatform(ElasticBase):
+
+    def __init__(self, parameters: dict, debug: bool, json: bool) -> None:
+
+        super().__init__(parameters)
+        self._debug = debug
+        self._json = json
+
+        if "kibana_url" not in self._parameters:
+            raise ValueError("ElasticPlatform: 'kibana_url' is not set.")
+
+        if "kibana_ca" not in self._parameters:
+            logger.error("ElasticPlatform: 'kibana_ca' is not set, defaulting to Unverified Requests.")
+            self._parameters["kibana_ca"] = False
+
+        if "schedule_interval" not in self._parameters:
+            logger.debug(
+                "ElasticPlatform: 'schedule_interval' is not set, using default of 1."
+            )
+            self._parameters["schedule_interval"] = "1"
+
+        if "schedule_interval_unit" not in self._parameters:
+            logger.debug(
+                "ElasticPlatform: 'schedule_interval_unit' is not set, using default of h."
+            )
+            self._parameters["schedule_interval_unit"] = "h"
+
+        if "license" not in self._parameters:
+            logger.debug("ElasticPlatform: 'license' is not set, using default of DRL.")
+            self._parameters["license"] = "DRL"
+
+        self.logger = ColorLogger("droid.platforms.sentinel.ElasticPlatform")
+
+        if self._json:
+            self.logger.enable_json_logging()
+
+        self._schedule_interval = self._parameters["schedule_interval"]
+        self._schedule_interval_unit = self._parameters["schedule_interval_unit"]
+        self._license = self._parameters["license"]
+        self._kibana_url = self._parameters["kibana_url"]
+        self._kibana_ca = self._parameters["kibana_ca"]
+
+        if "basic" in (
+            self._parameters["search_auth"] or self._parameters["export_auth"]
+        ):
+            self._username = self._parameters["username"]
+            self._password = self._parameters["password"]
+
+        if "alert_prefix" in self._parameters:
+            self._alert_prefix = self._parameters["alert_prefix"]
+        else:
+            self._alert_prefix = None
+
+    def level_parser(self, level):
+        level = level.lower()
+        if level == "critical":
+            return 99
+        elif level == "high":
+            return 73
+        elif level == "medium":
+            return 47
+        elif level == "low":
+            return 21
+        elif level == "informational":
+            return 1
+        else:
+            return 100
+
+    def mitre_attack_parser(self, tag):
+        tag = tag.replace("attack.", "")
+        subtechnique = None
+        if tag.startswith("ta"):
+            return None
+        if tag.startswith("t"):
+            technique = tag.upper()
+            if "." in technique:  # Subtechnique
+                subtechnique = technique
+                technique = technique.split(".")[0]
+            if technique in mitre_attack_techniques:
+                threats = []
+                technique_name = mitre_attack_techniques[technique]
+                if subtechnique:
+                    subtechnique_name = mitre_attack_techniques[subtechnique]
+                tactic_names = mitre_attack_techniques_tactics_mapping[technique]
+                for tactic in mitre_attack_tactics:
+                    if mitre_attack_tactics[tactic] in tactic_names:
+                        tactic_id = tactic
+                for tactic_name in tactic_names:
+                    tactic = {
+                        "tactic": {
+                            "id": tactic_id,
+                            "reference": f"https://attack.mitre.org/tactics/{tactic_id}",
+                            "name": tactic_name.title().replace("-", " "),
+                        }
+                    }
+                    if subtechnique:
+                        x, y = subtechnique.split(".")
+                        technique = {
+                            "technique": [
+                                {
+                                    "id": technique,
+                                    "reference": f"https://attack.mitre.org/techniques/{technique}",
+                                    "name": technique_name,
+                                    "subtechnique": [
+                                        {
+                                            "id": subtechnique,
+                                            "reference": f"https://attack.mitre.org/techniques/{x}/{y}",
+                                            "name": subtechnique_name,
+                                        }
+                                    ],
+                                }
+                            ]
+                        }
+                    else:
+                        technique = {
+                            "technique": [
+                                {
+                                    "id": technique,
+                                    "reference": f"https://attack.mitre.org/techniques/{technique}",
+                                    "name": technique_name,
+                                }
+                            ]
+                        }
+                    threat = {
+                        **tactic,
+                        "framework": "MITRE ATT&CK",
+                        **technique,
+                    }
+                    threats.append(threat)
+                    return threats
+        return None
+
+    def kibana_import_rule(self, ndjson):
+        ndjson = json.dumps(ndjson)
+        files = {
+            "file": ("rules.ndjson", io.BytesIO(ndjson.encode('utf-8')), 'application/x-ndjson'),
+        }
+
+        params = {
+            "overwrite": "true",
+        }
+        headers = {
+            "kbn-xsrf": "true",
+        }
+        response = requests.post(
+            self._kibana_url + "/api/detection_engine/rules/_import",
+            params=params,
+            headers=headers,
+            files=files,
+            verify=self._kibana_ca,
+            auth=HTTPBasicAuth(self._username, self._password),
+        )
+        if response.status_code == 200:
+            if response.json()["success"]:
+                logger.info(f"Imported successfully")
+            else:
+                logger.error(f"Failed to import")
+                pprint(response.json())
+                quit()
+        else:
+            logger.error(f"Failed to import")
+            pprint(response.json())
+            quit()
+
+    def create_search(self, rule_content, rule_converted, rule_file):
+        """Create an analytic rule in Sentinel
+        Create a scheduled alert rule in Sentinel
+        """
+        threat = []
+        tags = []
+        building_block = False
+        if rule_content["tags"]:
+            for tag in rule_content["tags"]:
+                if tag.startswith("attack."):
+                    parsed = self.mitre_attack_parser(tag)
+                    if parsed:
+                        threat += parsed
+                elif tag == "elastic.bb":
+                    building_block = True
+                else:
+                    tags.append(tag)
+        severity = rule_content["level"]
+        if severity == "informational":
+            severity = "low"
+        risk_score = self.level_parser(severity)
+        author = rule_content["author"]
+        if isinstance(author, str):
+            author = [author]
+
+        # Handling the display name
+        if self._alert_prefix:
+            display_name = self._alert_prefix + " " + rule_content["title"]
+        else:
+            display_name = rule_content["title"]
+        if building_block:
+            display_name = "BB - " + display_name
+        # Handling the status of the alert
+
+        if rule_content.get("custom", {}).get("disabled") is True:
+            enabled = False
+            self.logger.info(f"Successfully disabled the rule {rule_file}")
+        else:
+            enabled = True
+
+        ndjson = {
+            "id": rule_content["id"],
+            "name": display_name,
+            "enabled": True,
+            "interval": "1h",  # TODO: Use Parameter for this value
+            "author": author,
+            "description": rule_content["description"],
+            "rule_id": rule_content["id"],
+            "from": "now-65m",  # TODO: Use Parameter for this value
+            "immutable": False,
+            "license": "DRL",  # TODO: Use Parameter for this value
+            "output_index": "",  # TODO: Check if there should be a parameter for this
+            "meta": {"from": "5m"},  # TODO: Use Parameter for this value
+            "max_signals": 100,  # TODO: Check if there should be a parameter for this
+            "risk_score": risk_score,
+            "risk_score_mapping": [],  # TODO: Check if this should be configurable
+            "severity": severity,
+            "severity_mapping": [],  # TODO: Check if this should be configurable
+            "threat": threat,
+            "tags": tags,
+            "to": "now",
+            "version": 1,  # TODO: Check if this actually matters
+            "exceptions_list": [],
+            "related_integrations": [],
+            "required_fields": [],
+            "setup": "",
+            "type": "esql",
+            "language": "esql",
+            "index": None,
+            "query": rule_converted,
+            "filters": [],
+            "actions": [],
+        }
+        if "references" in rule_content:
+            ndjson["references"] = rule_content["references"]
+        if "elastic.bb" in tags:
+            ndjson["building_block_type"] = "default"
+        if "falsepositives" in rule_content:
+            ndjson["false_positives"] = rule_content["falsepositives"]
+
+        try:
+            self.kibana_import_rule(ndjson)
+            self.logger.info(f"Successfully exported the rule {rule_file}", extra={"rule_file": rule_file, "rule_converted": rule_converted, "rule_content": rule_content})
+        except Exception as e:
+            self.logger.error(f"Could not export the rule {rule_file}", extra={"rule_file": rule_file, "rule_converted": rule_converted, "rule_content": rule_content, "error": e})
+            raise

--- a/src/droid/platforms/elastic.py
+++ b/src/droid/platforms/elastic.py
@@ -262,15 +262,12 @@ class ElasticPlatform(ElasticBase):
         """
         threat = []
         tags = []
-        building_block = False
         if rule_content["tags"]:
             for tag in rule_content["tags"]:
                 if tag.startswith("attack."):
                     parsed = self.mitre_attack_parser(tag)
                     if parsed:
                         threat += parsed
-                elif tag == "elastic.bb":
-                    building_block = True
                 else:
                     tags.append(tag)
         severity = rule_content["level"]
@@ -280,6 +277,12 @@ class ElasticPlatform(ElasticBase):
         author = rule_content["author"]
         if isinstance(author, str):
             author = [author]
+
+        if rule_content.get("custom", {}).get("building_block") is True:
+            building_block = True
+            self.logger.info(f"Successfully building_block the rule {rule_file}")
+        else:
+            building_block = False
 
         # Handling the display name
         if self._alert_prefix:
@@ -295,7 +298,7 @@ class ElasticPlatform(ElasticBase):
             self.logger.info(f"Successfully disabled the rule {rule_file}")
         else:
             enabled = True
-        
+
         language = self._language
         if "custom" in rule_content and "raw_language" in rule_content["custom"]:
             language = rule_content["custom"]["raw_language"]
@@ -309,11 +312,6 @@ class ElasticPlatform(ElasticBase):
             # index = self.index_parser(rule_content["logsource"])
             index = ["logs-*"]  # Hardcoded to logs-* for now
 
-        if rule_content.get("custom", {}).get("disabled") is True:
-            enabled = False
-            self.logger.info(f"Successfully disabled the rule {rule_file}")
-        else:
-            enabled = True
         # Build the json_data for kibana import
         json_data = {
             # "id": rule_content["id"],

--- a/src/droid/platforms/elastic.py
+++ b/src/droid/platforms/elastic.py
@@ -46,7 +46,7 @@ class ElasticPlatform(AbstractPlatform):
             self._parameters["elastic_ca"] = None
         if "elastic_tls_verify" not in self._parameters:
             self._parameters["elastic_tls_verify"] = False
-            logger.error(
+            logger.warning(
                 "ElasticPlatform: 'elastic_tls_verify' is not set. Defaulting to not verifying TLS"
             )
 
@@ -422,7 +422,7 @@ class ElasticPlatform(AbstractPlatform):
             )
             raise
 
-    def run_eql_search(query, es_client=None, index=None):
+    def run_eql_search(self, query, es_client=None, index=None):
         response = es_client.eql.search(
             index=index,
             query=query,
@@ -450,7 +450,7 @@ class ElasticPlatform(AbstractPlatform):
         if "values" in response:
             return len(response["values"])
 
-    def run_elastic_search(self, rule_converted, rule_file, index, language):
+    def run_elastic_search(self, rule_converted, language=None, rule_content=None):
 
         es_client = Elasticsearch(
             self._elastic_hosts,
@@ -460,6 +460,11 @@ class ElasticPlatform(AbstractPlatform):
             request_timeout=300,
             max_retries=3,
         )
+
+        index = self._index_name
+        if rule_content and "custom" in rule_content and "raw_language" in rule_content["custom"]:
+            language = rule_content["custom"]["raw_language"]
+        print(language)
         if language == "esql":
             return self.run_esql_search(rule_converted, es_client=es_client)
         elif language == "eql":

--- a/src/droid/platforms/elastic.py
+++ b/src/droid/platforms/elastic.py
@@ -262,7 +262,7 @@ class ElasticPlatform(ElasticBase):
 
         # Handling the display name
         if self._alert_prefix:
-            display_name = self._alert_prefix + " " + rule_content["title"]
+            display_name = self._alert_prefix + " - " + rule_content["title"]
         else:
             display_name = rule_content["title"]
         if building_block:

--- a/src/droid/platforms/elastic.py
+++ b/src/droid/platforms/elastic.py
@@ -274,6 +274,7 @@ class ElasticPlatform(ElasticBase):
             language = rule_content["custom"]["raw_language"]
         else:
             language = "esql"
+        
         if language == "esql":
             index = None
         else:

--- a/src/droid/platforms/elastic.py
+++ b/src/droid/platforms/elastic.py
@@ -121,7 +121,7 @@ class ElasticPlatform(AbstractPlatform):
         if "building_block_prefix" in self._parameters:
             self._building_block_prefix = self._parameters["building_block_prefix"]
         else:
-            self._building_block_prefix = "BB - "
+            self._building_block_prefix = "BB"
 
         if self._kibana_ca:
             self._tls_verified = self._kibana_ca
@@ -440,7 +440,7 @@ class ElasticPlatform(AbstractPlatform):
         else:
             display_name = rule_content["title"]
         if building_block:
-            display_name = self._building_block_prefix + display_name
+            display_name = self._building_block_prefix + " - " + display_name
         # Handling the status of the alert
 
         if rule_content.get("custom", {}).get("disabled") is True:

--- a/src/droid/platforms/elastic.py
+++ b/src/droid/platforms/elastic.py
@@ -271,7 +271,7 @@ class ElasticPlatform(AbstractPlatform):
         else:
             return False
 
-    def get_search(self, rule_id):
+    def get_rule(self, rule_id):
         params = {
             "rule_id": rule_id,
         }
@@ -328,7 +328,7 @@ class ElasticPlatform(AbstractPlatform):
         return False
 
     def kibana_import_rule(self, json_data, rule_content):
-        existing_rule = self.get_search(json_data["rule_id"])
+        existing_rule = self.get_rule(json_data["rule_id"])
         if existing_rule and existing_rule["language"] != json_data["language"]:
             self.remove_rule(rule_content)
             self.logger.warning(
@@ -337,7 +337,7 @@ class ElasticPlatform(AbstractPlatform):
             existing_rule = False
         if existing_rule:
             if self.check_rule_changes(existing_rule, json_data):
-                
+
                 params = {
                     "overwrite": "true",
                 }
@@ -404,7 +404,7 @@ class ElasticPlatform(AbstractPlatform):
         """Create an analytic rule in Elastic
         Create a scheduled alert rule in Elastic
         """
-        
+
         threat = []
         tags = []
         if "tags" in rule_content and rule_content["tags"]:
@@ -510,8 +510,8 @@ class ElasticPlatform(AbstractPlatform):
             }
         except Exception as e:
             print(e)
-             
-        
+
+
         # TODO: It might be a good idea to add more optional fields
         if "references" in rule_content:
             json_data["references"] = rule_content["references"]
@@ -519,7 +519,7 @@ class ElasticPlatform(AbstractPlatform):
             json_data["building_block_type"] = "default"
         if "falsepositives" in rule_content:
             json_data["false_positives"] = rule_content["falsepositives"]
-        
+
         try:
             self.kibana_import_rule(json_data, rule_content)
             self.logger.info(

--- a/src/droid/platforms/elastic.py
+++ b/src/droid/platforms/elastic.py
@@ -259,7 +259,7 @@ class ElasticPlatform(ElasticBase):
             self.logger.error("No known index for Logsource")
             return ["logs-*"]
 
-    def create_search(self, rule_content, rule_converted, rule_file):
+    def create_search(self, rule_content, rule_converted, rule_file, index_name):
         """Create an analytic rule in Elastic
         Create a scheduled alert rule in Elastic
         """
@@ -308,6 +308,10 @@ class ElasticPlatform(ElasticBase):
 
         if language == "esql":
             index = None
+        elif index_name:
+            if isinstance(index_name, str):
+                index_name = [index_name]
+            index = index_name
         else:
             # TODO: There needs to be a discussion about how to handle this
             # Hardcoding Indexes is not a good idea

--- a/src/droid/platforms/elastic.py
+++ b/src/droid/platforms/elastic.py
@@ -186,7 +186,7 @@ class ElasticPlatform(AbstractPlatform):
                             break
         else:
             index_value = "logs-*"
-            self.logger.warning("No logsource found in the rule, using default index 'logs-*'")
+            logger.warning("No logsource found in the rule, using default index 'logs-*'")
         if isinstance(index_value, str):
             self._index_name = []
             self._index_name.append(index_value)

--- a/src/droid/platforms/elastic.py
+++ b/src/droid/platforms/elastic.py
@@ -43,10 +43,9 @@ class ElasticPlatform(ElasticBase):
             raise ValueError("ElasticPlatform: 'kibana_url' is not set.")
 
         if "kibana_ca" not in self._parameters:
-            logger.error(
-                "ElasticPlatform: 'kibana_ca' is not set, defaulting to Unverified Requests."
-            )
             self._parameters["kibana_ca"] = False
+        if "tls_verify" not in self._parameters:
+            self._parameters["tls_verify"] = True
 
         if "schedule_interval" not in self._parameters:
             logger.debug(
@@ -74,11 +73,10 @@ class ElasticPlatform(ElasticBase):
         self._license = self._parameters["license"]
         self._kibana_url = self._parameters["kibana_url"]
         self._kibana_ca = self._parameters["kibana_ca"]
+        self._tls_verify = self._parameters["tls_verify"]
         self._language = language
 
-        if "basic" in (
-            self._parameters["search_auth"] or self._parameters["export_auth"]
-        ):
+        if self._parameters["auth_method"] == "basic":
             self._username = self._parameters["username"]
             self._password = self._parameters["password"]
 
@@ -86,6 +84,11 @@ class ElasticPlatform(ElasticBase):
             self._alert_prefix = self._parameters["alert_prefix"]
         else:
             self._alert_prefix = None
+
+        if self._kibana_ca:
+            self._tls_verified = self._kibana_ca
+        else:
+            self._tls_verified = self._tls_verify
 
     def level_parser(self, level):
         level = level.lower()
@@ -178,7 +181,7 @@ class ElasticPlatform(ElasticBase):
             self._kibana_url + "/api/detection_engine/rules",
             params=params,
             headers=headers,
-            verify=self._kibana_ca,
+            verify=self._tls_verified,
             auth=HTTPBasicAuth(self._username, self._password),
         )
         if response.status_code == 200:
@@ -197,7 +200,7 @@ class ElasticPlatform(ElasticBase):
             self._kibana_url + "/api/detection_engine/rules",
             params=params,
             headers=headers,
-            verify=self._kibana_ca,
+            verify=self._tls_verified,
             auth=HTTPBasicAuth(self._username, self._password),
         )
         if response.status_code == 200:
@@ -224,7 +227,7 @@ class ElasticPlatform(ElasticBase):
                 params=params,
                 headers=headers,
                 json=json_data,
-                verify=self._kibana_ca,
+                verify=self._tls_verified,
                 auth=HTTPBasicAuth(self._username, self._password),
             )
         else:
@@ -235,7 +238,7 @@ class ElasticPlatform(ElasticBase):
                 self._kibana_url + "/api/detection_engine/rules",
                 headers=headers,
                 json=json_data,
-                verify=self._kibana_ca,
+                verify=self._tls_verified,
                 auth=HTTPBasicAuth(self._username, self._password),
             )
 

--- a/src/droid/platforms/elastic.py
+++ b/src/droid/platforms/elastic.py
@@ -262,11 +262,16 @@ class ElasticPlatform(ElasticBase):
             # Hardcoding Indexes is not a good idea
             # Could maybe use a custom field in the rule to specify the index?
             index = self.index_parser(rule_content["logsource"])
+        if rule_content.get("custom", {}).get("disabled") is True:
+            enabled = False
+            self.logger.info(f"Successfully disabled the rule {rule_file}")
+        else:
+            enabled = True
         # Build the ndjson for kibana import
         ndjson = {
             "id": rule_content["id"],
             "name": display_name,
-            "enabled": True,
+            "enabled": enabled,
             "interval": f"{self._schedule_interval}{self._schedule_interval_unit}",
             "author": author,
             "description": rule_content["description"],

--- a/src/droid/platforms/elastic.py
+++ b/src/droid/platforms/elastic.py
@@ -186,6 +186,7 @@ class ElasticPlatform(AbstractPlatform):
                             break
         else:
             index_value = "logs-*"
+            self.logger.warning("No logsource found in the rule, using default index 'logs-*'")
         if isinstance(index_value, str):
             self._index_name = []
             self._index_name.append(index_value)

--- a/src/droid/platforms/elastic.py
+++ b/src/droid/platforms/elastic.py
@@ -433,14 +433,16 @@ class ElasticPlatform(AbstractPlatform):
         search_id = response["id"]
         es_client.eql.get_status(id=search_id)
         while es_client.eql.get_status(id=search_id)["is_running"]:
-            print(f"Query {search_id} is still running")
+            logger.debug(f"Query {search_id} is still running")
             # print(es_client.eql.get_status(id=search_id))
             time.sleep(10)
-        print(f"Query {search_id} is done")
+        logger.debug(f"Query {search_id} is done")
         results = es_client.eql.get(id=search_id)
         es_client.eql.delete(id=search_id)
         if "hits" in results:
             return results["hits"]["total"]["value"]
+        else:
+            return None
 
     def run_esql_search(self, query, es_client=None):
         response = es_client.esql.query(
@@ -469,3 +471,5 @@ class ElasticPlatform(AbstractPlatform):
             return self.run_esql_search(rule_converted, es_client=es_client)
         elif language == "eql":
             return self.run_eql_search(rule_converted, es_client=es_client, index=index)
+        else:
+            raise ValueError(f"Unsupported language: {language}")

--- a/src/droid/platforms/elastic.py
+++ b/src/droid/platforms/elastic.py
@@ -171,6 +171,7 @@ class ElasticPlatform(AbstractPlatform):
         return None
 
     def get_index_name(self, pipeline, rule_content):
+        index_value = "logs-*"
         if "logsource" in rule_content:
             for item in pipeline.items:
                 if hasattr(item, 'transformation') and hasattr(item.transformation, 'key') and hasattr(item.transformation, 'val'):
@@ -185,7 +186,6 @@ class ElasticPlatform(AbstractPlatform):
                             self.logger.info(f"The value of the key 'index' is: {index_value}")
                             break
         else:
-            index_value = "logs-*"
             logger.warning("No logsource found in the rule, using default index 'logs-*'")
         if isinstance(index_value, str):
             self._index_name = []

--- a/src/droid/platforms/elastic.py
+++ b/src/droid/platforms/elastic.py
@@ -71,6 +71,18 @@ class ElasticPlatform(AbstractPlatform):
             logger.debug("ElasticPlatform: 'license' is not set, using default of DRL.")
             self._parameters["license"] = "DRL"
 
+        if "eql_search_range_gte" not in self._parameters:
+            logger.debug(
+                "ElasticPlatform: 'eql_search_range_gte' is not set, using default of 1h."
+            )
+            self._parameters["eql_search_range_gte"] = "now-24h"
+        if "esql_search_range_gte" not in self._parameters:
+            logger.debug(
+                "ElasticPlatform: 'esql_search_range_gte' is not set, using default of 1h."
+            )
+            self._parameters["esql_search_range_gte"] = "now-1h"
+
+
         self.logger = ColorLogger("droid.platforms.elastic.ElasticPlatform")
 
         if self._json:
@@ -251,7 +263,7 @@ class ElasticPlatform(AbstractPlatform):
         else:
             return False
 
-    def get_rule(self, rule_id):
+    def get_search(self, rule_id):
         params = {
             "rule_id": rule_id,
         }
@@ -271,7 +283,7 @@ class ElasticPlatform(AbstractPlatform):
             return False
 
     def kibana_import_rule(self, json_data, rule_content):
-        existing_rule = self.get_rule(json_data["rule_id"])
+        existing_rule = self.get_search(json_data["rule_id"])
         if existing_rule and existing_rule["language"] != json_data["language"]:
             self.remove_rule(rule_content)
             self.logger.warning(

--- a/src/droid/platforms/elastic.py
+++ b/src/droid/platforms/elastic.py
@@ -193,6 +193,20 @@ class ElasticPlatform(ElasticBase):
             pprint(response.json())
             quit()
 
+
+    def index_parser(self, logsource):
+        if "product" in logsource:
+            logsource = logsource["product"]
+        else:
+            logger.error("No Product Specified in Logsource")
+            return None
+        if logsource.lower() == "windows":
+            return ["logs-system.*", "logs-windows.*"]
+        else:
+            logger.error("No known index for Logsource")
+            return None
+
+
     def create_search(self, rule_content, rule_converted, rule_file):
         """Create an analytic rule in Sentinel
         Create a scheduled alert rule in Sentinel
@@ -237,6 +251,10 @@ class ElasticPlatform(ElasticBase):
             language = rule_content["custom"]["raw_language"]
         else: 
             language = "esql"
+        if language == "esql":
+            index = None
+        else:
+            index = self.index_parser(rule_content["logsource"])
         ndjson = {
             "id": rule_content["id"],
             "name": display_name,
@@ -265,7 +283,7 @@ class ElasticPlatform(ElasticBase):
             "setup": "",
             "type": language,
             "language": language,
-            "index": None,
+            "index": index,
             "query": rule_converted,
             "filters": [],
             "actions": [],

--- a/src/droid/platforms/elastic.py
+++ b/src/droid/platforms/elastic.py
@@ -243,7 +243,7 @@ class ElasticPlatform(ElasticBase):
             "rule_id": rule_content["id"],
             "from": f"now-{self._schedule_interval}{self._schedule_interval_unit}", # TODO: This should actually always be slightly more than the interval, either make it a parameter or calculate it.
             "immutable": False,
-            "license": "DRL",  # TODO: Use Parameter for this value
+            "license": self._license,
             "output_index": "",  # TODO: Check if there should be a parameter for this
             "meta": {"from": "5m"},  # TODO: Use Parameter for this value
             "max_signals": 100,  # TODO: Check if there should be a parameter for this

--- a/src/droid/platforms/elastic.py
+++ b/src/droid/platforms/elastic.py
@@ -188,7 +188,7 @@ class ElasticPlatform(ElasticBase):
         existing_rule = self.get_rule(json_data["rule_id"])
         if existing_rule:
             if existing_rule["language"] != json_data["language"]:
-                logger.error(
+                self.logger.error(
                     f"Rule '{json_data['name']}' already exists with a different language. Delete the existing rule or change the language of the rule"
                 )
                 return
@@ -217,11 +217,9 @@ class ElasticPlatform(ElasticBase):
                 verify=self._kibana_ca,
                 auth=HTTPBasicAuth(self._username, self._password),
             )
+
         if response.status_code == 200:
-            if response.json()["success"]:
-                logger.info(f"Imported successfully")
-            else:
-                raise Exception(response.json())
+            return True
         else:
             raise Exception(response.text)
 
@@ -229,12 +227,12 @@ class ElasticPlatform(ElasticBase):
         if "product" in logsource:
             logsource = logsource["product"]
         else:
-            logger.error("No Product Specified in Logsource")
+            self.logger.error("No Product Specified in Logsource")
             return None
         if logsource.lower() == "windows":
             return ["logs-system.*", "logs-windows.*"]
         else:
-            logger.error("No known index for Logsource")
+            self.logger.error("No known index for Logsource")
             return ["logs-*"]
 
     def create_search(self, rule_content, rule_converted, rule_file):

--- a/src/droid/platforms/elastic.py
+++ b/src/droid/platforms/elastic.py
@@ -118,6 +118,11 @@ class ElasticPlatform(AbstractPlatform):
         else:
             self._alert_prefix = None
 
+        if "building_block_prefix" in self._parameters:
+            self._building_block_prefix = self._parameters["building_block_prefix"]
+        else:
+            self._building_block_prefix = "BB - "
+
         if self._kibana_ca:
             self._tls_verified = self._kibana_ca
         else:
@@ -435,7 +440,7 @@ class ElasticPlatform(AbstractPlatform):
         else:
             display_name = rule_content["title"]
         if building_block:
-            display_name = "BB - " + display_name
+            display_name = self._building_block_prefix + display_name
         # Handling the status of the alert
 
         if rule_content.get("custom", {}).get("disabled") is True:

--- a/src/droid/platforms/elastic.py
+++ b/src/droid/platforms/elastic.py
@@ -262,7 +262,7 @@ class ElasticPlatform(ElasticBase):
         """
         threat = []
         tags = []
-        if rule_content["tags"]:
+        if "tags" in rule_content and rule_content["tags"]:
             for tag in rule_content["tags"]:
                 if tag.startswith("attack."):
                     parsed = self.mitre_attack_parser(tag)

--- a/src/droid/platforms/elastic.py
+++ b/src/droid/platforms/elastic.py
@@ -369,7 +369,9 @@ class ElasticPlatform(AbstractPlatform):
             return query
         # (^[^\|]*) - Match everything before the first pipe
         try:
-            query = re.sub(r"(^[^\|]*)", r"\1 METADATA _id, _index, _version ", query)
+            # Older Elastic Versions need brackets around the Metadata fields
+            # It is possible that this will deprecated in the future
+            query = re.sub(r"(^[^\|]*)", r"\1 [METADATA _id, _index, _version] ", query)
         except Exception as e:
             logger.error(f"Error while preparing rule for deduplication {e}")
         return query

--- a/src/droid/platforms/sentinel.py
+++ b/src/droid/platforms/sentinel.py
@@ -30,7 +30,8 @@ class SentinelPlatform(AbstractPlatform):
 
         super().__init__(name="Sentinel")
 
-        super().__init__(parameters)
+        self._parameters = parameters
+
         self._debug = debug
         self._json = json
 
@@ -241,7 +242,7 @@ class SentinelPlatform(AbstractPlatform):
         except Exception as e:
             self.logger.error(f"Rule {rule_file} error: {e}")
 
-    def get_search(self, rule_content, rule_file):
+    def get_rule(self, rule_content, rule_file):
         """Retrieve a scheduled alert rule in Sentinel
         Remove a scheduled alert rule in Sentinel
         """
@@ -270,7 +271,7 @@ class SentinelPlatform(AbstractPlatform):
             self.logger.error(f"Could not retrieve the rule {rule_file}")
             raise
 
-    def remove_search(self, rule_content, rule_converted, rule_file):
+    def remove_rule(self, rule_content, rule_converted, rule_file):
         """Remove an analytic rule in Sentinel
         Remove a scheduled alert rule in Sentinel
         """

--- a/src/droid/platforms/sentinel.py
+++ b/src/droid/platforms/sentinel.py
@@ -18,23 +18,17 @@ from azure.mgmt.securityinsight.models import GroupingConfiguration
 from azure.monitor.query import LogsQueryClient, LogsQueryStatus
 from datetime import datetime, timedelta, timezone
 from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
+from droid.abstracts import AbstractPlatform
 from droid.color import ColorLogger
 
 logger = ColorLogger("droid.platforms.sentinel")
 
-class SentinelBase:
-    """Sentinel base class
 
-    Base class for importing datasource/product data
-    """
-
-    def __init__(self, parameters: dict) -> None:
-        self.logger = ColorLogger("droid.platforms.sentinel.SentinelBase")
-        self._parameters = parameters
-
-class SentinelPlatform(SentinelBase):
+class SentinelPlatform(AbstractPlatform):
 
     def __init__(self, parameters: dict, debug: bool, json: bool) -> None:
+
+        super().__init__(name="Sentinel")
 
         super().__init__(parameters)
         self._debug = debug
@@ -295,7 +289,7 @@ class SentinelPlatform(SentinelBase):
             self.logger.error(f"Could not delete the rule {rule_file}", extra={"rule_file": rule_file, "rule_converted": rule_converted, "rule_content": rule_content, "error": e})
             raise
 
-    def create_search(self, rule_content, rule_converted, rule_file):
+    def create_rule(self, rule_content, rule_converted, rule_file):
         """Create an analytic rule in Sentinel
         Create a scheduled alert rule in Sentinel
         """

--- a/src/droid/platforms/splunk.py
+++ b/src/droid/platforms/splunk.py
@@ -184,6 +184,23 @@ class SplunkPlatform(AbstractPlatform):
 
         return group_match
 
+
+    def get_rule(self, rule_content: dict, rule_converted: str, rule_file: str):
+
+        alert_name = rule_content["title"]
+
+        service = client.connect(
+            host= self._url,
+            port=self._port,
+            username=self._user,
+            password=self._password,
+            app=self._app)
+
+        if self.search_savedsearch(rule_content): # If the rule already exists
+            return self.search_savedsearch(rule_content)
+        else:
+            return False
+
     def create_rule(self, rule_content: dict, rule_converted: str, rule_file: str):
         earliest_time = self._earliest_time
         latest_time = self._latest_time

--- a/src/droid/search.py
+++ b/src/droid/search.py
@@ -68,11 +68,11 @@ def search_rule_elastic(rule_converted, platform: ElasticPlatform, rule_file, pa
         logger.info(f"Successfully searched the rule {rule_file}")
 
         if result > 0: # If the rule has match
-            logger.warning(f'(Sentinel) Match found for {rule_file}')
+            logger.warning(f'(Elastic) {result} hits found for {rule_file}')
             search_warning = True
             return error, search_warning
         else:
-            logger.info(f"(Sentinel) No hits for {rule_file}")
+            logger.info(f"(Elastic) No hits for {rule_file}")
             return error, search_warning
 
     except Exception as e:

--- a/src/droid/search.py
+++ b/src/droid/search.py
@@ -60,10 +60,10 @@ def search_rule_sentinel(rule_converted, platform: SentinelPlatform, rule_file, 
         error = True
         return error, search_warning
 
-def search_rule_elastic(rule_converted, platform: ElasticPlatform, rule_file, parameters, logger, error, search_warning, index, platform_name):
+def search_rule_elastic(rule_converted, platform: ElasticPlatform, rule_file, parameters, logger, error, search_warning, rule_content, platform_name):
 
     try:
-        result: int = platform.run_elastic_search(rule_converted, rule_file, index, platform_name)
+        result: int = platform.run_elastic_search(rule_converted, platform_name, rule_content)
 
         logger.info(f"Successfully searched the rule {rule_file}")
 
@@ -80,7 +80,7 @@ def search_rule_elastic(rule_converted, platform: ElasticPlatform, rule_file, pa
         error = True
         return error, search_warning
 
-def search_rule(parameters, rule_content, rule_converted, platform, rule_file, error, search_warning, index=None):
+def search_rule(parameters, rule_content, rule_converted, platform, rule_file, error, search_warning):
 
     logger = ColorLogger("droid.search")
 
@@ -100,7 +100,7 @@ def search_rule(parameters, rule_content, rule_converted, platform, rule_file, e
     elif parameters.platform in ["esql", "eql"]:
         error, search_warning = search_rule_elastic(rule_converted, platform, rule_file,
                                                     parameters, logger, error, search_warning,
-                                                    index, parameters.platform)
+                                                    rule_content, parameters.platform)
         return error, search_warning
     elif 'azure' or 'defender' in parameters.platform:
         if parameters.mssp:


### PR DESCRIPTION
I am building the converter and output pipeline für Elastic.
There will be two plattforms that can be used, esql (ES|QL) or eql.
However it should always be esql prefered since it supports more sigma features.

When it comes to raw rule import, both are valid options, since both languages have their own advantages.
I will not implement KQL (Kibana Query Language) since there are no obvious benefits.

# Todos:
- [x] Renaming Plattform to elastic-xxx
- [x] Add Documentation of new Variables
- [x] Use variables for the policy executions
- [x] Add Search Export
- [x] Add Run Search
- [x] Add Raw Rules for ES|QL &  EQL -> Here it makes sense to do both languages
- [x] Testcases
- [x] Have a discussion about how to push the data: One at a time is the solution, I've converted to JSON import instead of 
NDJSON which already spedup the process by a lot
- [x] Add disabling of rules
- [x] Add deleting rules
- [x] Add Integrity check
- [x] Implement push only on rule change
- [x] Have a think about this problem: https://www.elastic.co/guide/en/security/8.15/rules-ui-create.html#esql-non-agg-query-dedupe
- [x] Fix the index selection for raw eql rules, right now they are done via custom field index, but that's just not OK
- [x] Add option for BuildingBlock prefix, right now it's automatically added if it's a BB, but maybe not everyone wants that