### PR TITLE
Add support for reading credentials from a file for Microsoft Defender

### DIFF
--- a/src/droid/__main__.py
+++ b/src/droid/__main__.py
@@ -177,7 +177,7 @@ def droid_platform_config(args, config_path):
 
         if args.export or args.search or args.integrity:
 
-            if config["search_auth"] == "app":
+            if config["search_auth"] == "app" and not "credential_file" in config:
 
                 if environ.get('DROID_AZURE_TENANT_ID'):
                     tenant_id = environ.get('DROID_AZURE_TENANT_ID')

--- a/src/droid/__main__.py
+++ b/src/droid/__main__.py
@@ -197,7 +197,7 @@ def droid_platform_config(args, config_path):
                 else:
                     raise Exception("Please use: export DROID_AZURE_CLIENT_SECRET=<client_secret>")
 
-            elif config["export_auth"] == "app" and args.export:
+            elif config["export_auth"] == "app" and args.export and not "credential_file" in config:
 
                 if environ.get('DROID_AZURE_TENANT_ID'):
                     tenant_id = environ.get('DROID_AZURE_TENANT_ID')

--- a/src/droid/platforms/ms_xdr.py
+++ b/src/droid/platforms/ms_xdr.py
@@ -49,14 +49,6 @@ class MicrosoftXDRPlatform(AbstractPlatform):
 
         self._query_period = self._parameters["query_period"]
 
-        if 'app' in (self._parameters["search_auth"] or self._parameters["export_auth"]):
-            self._tenant_id = self._parameters["tenant_id"]
-            self._client_id = self._parameters["client_id"]
-            self._client_secret = self._parameters["client_secret"]
-        else:
-            # Default auth
-            self._tenant_id = self._parameters["tenant_id"]
-
         if "credential_file" in self._parameters:
             try:
                 with open(self._parameters["credential_file"], "r") as file:
@@ -66,6 +58,14 @@ class MicrosoftXDRPlatform(AbstractPlatform):
                     self._tenant_id = credentials["tenant_id"]
             except Exception as e:
                 raise Exception(f"Error while reading the credential file {e}")
+        elif 'app' in (self._parameters["search_auth"] or self._parameters["export_auth"]):
+            self._tenant_id = self._parameters["tenant_id"]
+            self._client_id = self._parameters["client_id"]
+            self._client_secret = self._parameters["client_secret"]
+        else:
+            # Default auth
+            self._tenant_id = self._parameters["tenant_id"]
+
                 
 
 

--- a/src/droid/platforms/ms_xdr.py
+++ b/src/droid/platforms/ms_xdr.py
@@ -67,7 +67,6 @@ class MicrosoftXDRPlatform(AbstractPlatform):
             self._tenant_id = self._parameters["tenant_id"]
 
 
-
         self._api_base_url = "https://graph.microsoft.com/beta"
         self._token = self.acquire_token()
         self._headers = {

--- a/src/droid/platforms/ms_xdr.py
+++ b/src/droid/platforms/ms_xdr.py
@@ -66,7 +66,6 @@ class MicrosoftXDRPlatform(AbstractPlatform):
             # Default auth
             self._tenant_id = self._parameters["tenant_id"]
 
-                
 
 
         self._api_base_url = "https://graph.microsoft.com/beta"

--- a/src/droid/platforms/ms_xdr.py
+++ b/src/droid/platforms/ms_xdr.py
@@ -66,7 +66,6 @@ class MicrosoftXDRPlatform(AbstractPlatform):
             # Default auth
             self._tenant_id = self._parameters["tenant_id"]
 
-
         self._api_base_url = "https://graph.microsoft.com/beta"
         self._token = self.acquire_token()
         self._headers = {

--- a/src/droid/platforms/ms_xdr.py
+++ b/src/droid/platforms/ms_xdr.py
@@ -5,6 +5,7 @@ Module for Microsoft XDR
 import re
 import requests
 import time
+import yaml
 
 from pprint import pprint
 from droid.abstracts import AbstractPlatform
@@ -55,6 +56,18 @@ class MicrosoftXDRPlatform(AbstractPlatform):
         else:
             # Default auth
             self._tenant_id = self._parameters["tenant_id"]
+
+        if "credential_file" in self._parameters:
+            try:
+                with open(self._parameters["credential_file"], "r") as file:
+                    credentials = yaml.safe_load(file)
+                    self._client_id = credentials["client_id"]
+                    self._client_secret = credentials["client_secret"]
+                    self._tenant_id = credentials["tenant_id"]
+            except Exception as e:
+                raise Exception(f"Error while reading the credential file {e}")
+                
+
 
         self._api_base_url = "https://graph.microsoft.com/beta"
         self._token = self.acquire_token()


### PR DESCRIPTION
Some people would maybe prefer a credential file instead of having to set environment variabled.

I propose to add the following parameter to the config toml.

```toml
credential_file = "microsoft365defender-authentication.yml"
```

If this parameter is set, the yaml file will be read and prefered over the environment variables
YAML Structure:

```yaml
client_id: 123456
client_secret: 123456
tenant_id: 123456
```