### PR TITLE
Adding Validation for Query Perdiod in XDR Backend

### DIFF
--- a/src/droid/platforms/ms_xdr.py
+++ b/src/droid/platforms/ms_xdr.py
@@ -28,24 +28,16 @@ class MicrosoftXDRPlatform(AbstractPlatform):
         self._parameters = parameters
         self._export_mssp = export_mssp
 
-        self._query_period_groups = self._parameters.get("rule_parameters", {}).get("query_period_groups")
+        self._query_period_groups = self._parameters.get("rule_parameters", {}).get(
+            "query_period_groups"
+        )
 
         if "query_period" not in self._parameters:
             raise Exception(
                 'MicrosoftXDRPlatform: "query_period" parameter is required.'
             )
-        elif self._parameters["query_period"].upper() not in [
-            "0",
-            "1H",
-            "3H",
-            "12H",
-            "24H",
-        ]:
-            raise Exception(
-                'MicrosoftXDRPlatform: "query_period" parameter must be one of "0", "1H", "3H", "12H" or "24H".'
-            )
-
-        self._query_period = self._parameters["query_period"]
+        else:
+            self._query_period = self._parameters["query_period"]
 
         if "credential_file" in self._parameters:
             try:
@@ -222,14 +214,15 @@ class MicrosoftXDRPlatform(AbstractPlatform):
         """Process the query period time
         :return: a query period time
         """
-        if query_period.upper() in [
+        query_period = str(query_period.upper())
+        if query_period in [
             "0",
             "1H",
             "3H",
             "12H",
             "24H",
         ]:
-            return query_period.upper()
+            return query_period
         else:
             self.logger.error(
                 f"Sigma Query Period must be one of '0', '1H', '3H', '12H' or '24H', used value provided in the config {self._query_period} - {rule_file}"

--- a/src/droid/platforms/ms_xdr.py
+++ b/src/droid/platforms/ms_xdr.py
@@ -214,7 +214,7 @@ class MicrosoftXDRPlatform(AbstractPlatform):
         """Process the query period time
         :return: a query period time
         """
-        query_period = str(query_period.upper())
+        query_period = str(query_period).upper()
         if query_period in [
             "0",
             "1H",


### PR DESCRIPTION
The XDR backend fails right now if the input is an INT, which is technically allowed by Microsoft if that INT is 0
This fix tries to address that problem.