### PR TITLE
add: Add Hook for Azure Token Retrieval from Custom App

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ azure-mgmt-monitor==6.0.2
 azure-mgmt-resource==23.0.1
 azure-mgmt-resourcegraph==8.0.0
 azure-mgmt-securityinsight==2.0.0b2
-azure-monitor-query==1.3.0
+azure-monitor-query==1.4.1
 splunk-sdk==2.0.1
 colorama==0.4.6
 python-json-logger==2.0.7


### PR DESCRIPTION
### Description

In this PR we're adding the ability to retrieve Azure Tokens from any custom app via a hook. 

If the environment variable `DROID_AZURE_TOKEN_HOOK` is set with a URL, the hook attempts to acquire the token from that URL via a `GET` request. The response should contain a JSON object with the `access_token` key, which will be used as the token.

The hook function  supports dynamic URL configuration using placeholders:

- `{TENANT_ID}`: Replaced with the provided or default tenant ID.
- `{SCOPE}`: Replaced with the requested scope.

Additional infos:

- Uses the cached token if it is still valid and the scope matches.
- Supports retries for token retrieval, with retry count and delay.
- If `DROID_AZURE_TOKEN_X_API_KEY` environment variable is present, it will be included in the request headers.
