### PR TITLE
feat(microsoft_sentinel): Support custom entity grouping configuration per rule

### DIFF
--- a/src/droid/platforms/sentinel.py
+++ b/src/droid/platforms/sentinel.py
@@ -676,6 +676,11 @@ class SentinelPlatform(AbstractPlatform):
                     lookback_duration=timedelta(hours=self._grouping_period),
                     matching_method=self._grouping_method
                 )
+                if rule_content.get("custom", {}).get("grouping_period"):
+                    grouping_config.lookback_duration = timedelta(hours=rule_content["custom"]["grouping_period"])
+                if rule_content.get("custom", {}).get("grouping_matching_entities"):
+                    grouping_config.matching_method = "Selected"
+                    grouping_config.group_by_entities = rule_content["custom"]["grouping_matching_entities"]
             else:
                 grouping_config = None
         else:
@@ -687,6 +692,11 @@ class SentinelPlatform(AbstractPlatform):
                     lookback_duration=timedelta(hours=self._grouping_period),
                     matching_method=self._grouping_method
                 )
+                if rule_content.get("custom", {}).get("grouping_period"):
+                    grouping_config.lookback_duration = timedelta(hours=rule_content["custom"]["grouping_period"])
+                if rule_content.get("custom", {}).get("grouping_matching_entities"):
+                    grouping_config.matching_method = "Selected"
+                    grouping_config.group_by_entities = rule_content["custom"]["grouping_matching_entities"]
             else:
                 grouping_config = None
 


### PR DESCRIPTION
### Description

In this PR, we introduce two new custom fields for Microsoft Sentinel analytics rules:

1. Handle `grouping_matching_entities`

Allows specifying which entity types should be used for incident grouping. When this field is present, the matching method is automatically set to "Selected".

Example:

```
custom:
  grouping_matching_entities:
    - IP
    - Account
    - RegistryKey
```

2. Add `grouping_period` override

The existing `grouping_period` custom field now works across both incident creation scenarios (when incident_status is True or False).

```
custom:
  grouping_period: 24  # 24 hours
```
