### PR TITLE
chore: remove archived and unused QA dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,5 +33,5 @@ jobs:
 
     - name: Run tests
       run: |
-        export PYTHONPATH=$PYTHONPATH:./src/. && pytest --open-files --random-order
+        export PYTHONPATH=$PYTHONPATH:./src/. && pytest --random-order
 

--- a/requirements-qa.txt
+++ b/requirements-qa.txt
@@ -1,5 +1,4 @@
-pytest==7.4.3
-pytest-openfiles==0.5.0
+pytest==9.0.3
 pytest-random-order==1.1.0
 bump-my-version==0.17.3
 setuptools==78.1.1

--- a/requirements-qa.txt
+++ b/requirements-qa.txt
@@ -1,5 +1,2 @@
 pytest==9.0.3
 pytest-random-order==1.1.0
-bump-my-version==0.17.3
-setuptools==78.1.1
-six==1.17.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,3 @@ where=src
 [options.entry_points]
 console_scripts =
     droid = droid.__main__:main
-
-[tool:pytest]
-open_files_ignore =
-    */pysigma/*


### PR DESCRIPTION
## Description

- Remove `pytest-openfiles` (archived upstream) and its `--open-files` flag from the CI test command and `open_files_ignore` config from `setup.cfg`
- Remove unused dependencies from `requirements-qa.txt`: `bump-my-version` (no config file, never used), `setuptools` (available in any standard Python env), `six` (Python 2/3 compat lib, unused)
- Bump `pytest` from 7.4.3 to 9.0.3