### PR TITLE
feat(convert): add format_correlation and pipelines_correlation override

### DIFF
--- a/src/droid/convert.py
+++ b/src/droid/convert.py
@@ -125,6 +125,20 @@ class Conversion:
         return sigma_rule
 
     @staticmethod
+    def _file_has_correlation(rule_file) -> bool:
+        """Return True if any YAML document in the rule file is a correlation rule.
+
+        Correlation files typically contain the referenced atomic rules followed by the
+        `correlation:` document, so we must scan all documents — not just the first one
+        returned by `load_rule`.
+        """
+        with open(rule_file, "r", encoding="utf-8") as stream:
+            for doc in yaml.safe_load_all(stream):
+                if isinstance(doc, dict) and "correlation" in doc:
+                    return True
+        return False
+
+    @staticmethod
     def _rule_has_regex_modifier(rule_content) -> bool:
         """Check if a Sigma rule uses the |re (regex) modifier in its detection section.
 
@@ -173,10 +187,20 @@ class Conversion:
 
         if pipeline_config_group:
             rule_supported = True
-            pipeline_config = self._parameters[pipeline_config_group]["pipelines"]
-            # Format
-            if "format" in self._parameters[pipeline_config_group]:
-                self._format = self._parameters[pipeline_config_group]["format"]
+            pipeline_params = self._parameters[pipeline_config_group]
+            # Correlation rules can override both the pipelines list (`pipelines_correlation`)
+            # and the output format (`format_correlation`) to fall back to a
+            # non-data-model pipeline + default format because data_model finalizers don't
+            # work on correlation rules.
+            is_correlation_rule = "correlation" in rule_content or self._file_has_correlation(rule_file)
+            if is_correlation_rule and "pipelines_correlation" in pipeline_params:
+                pipeline_config = pipeline_params["pipelines_correlation"]
+            else:
+                pipeline_config = pipeline_params["pipelines"]
+            if is_correlation_rule and "format_correlation" in pipeline_params:
+                self._format = pipeline_params["format_correlation"]
+            elif "format" in pipeline_params:
+                self._format = pipeline_params["format"]
             else:
                 self._format = "default"
         else:

--- a/tests/files/sigma-rules/valid/convert_valid_correlation_rule.yml
+++ b/tests/files/sigma-rules/valid/convert_valid_correlation_rule.yml
@@ -1,0 +1,45 @@
+title: Convert Correlation Atomic Rule 1
+id: 11111111-1111-1111-1111-111111111111
+name: convert_correlation_atomic_1
+status: test
+description: Atomic rule referenced by the correlation rule below.
+author: pizza53
+date: 2026-06-02
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        CommandLine|contains: 'foo.exe'
+    condition: selection
+level: high
+---
+title: Convert Correlation Atomic Rule 2
+id: 22222222-2222-2222-2222-222222222222
+name: convert_correlation_atomic_2
+status: test
+description: Atomic rule referenced by the correlation rule below.
+author: pizza53
+date: 2026-06-02
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        CommandLine|contains: 'bar.exe'
+    condition: selection
+level: high
+---
+title: Convert Temporal Correlation Test
+id: 33333333-3333-3333-3333-333333333333
+status: test
+description: Temporal correlation over the two atomic rules above.
+author: pizza53
+date: 2026-06-02
+correlation:
+    type: temporal
+    rules:
+        - convert_correlation_atomic_1
+        - convert_correlation_atomic_2
+    timespan: 10m
+level: high

--- a/tests/files/test_config_correlation.toml
+++ b/tests/files/test_config_correlation.toml
@@ -1,0 +1,44 @@
+# This is a TOML document config exercising format_correlation / pipelines_correlation overrides
+
+title = "droid configuration file"
+
+[base]
+
+raw_rules_directory = "rules-raw"
+sigma_validation_config = "tests/files/test_validate.yml"
+
+[platforms]
+
+[platforms.splunk]
+
+url = "splunk23.pizza-planet.local"
+verify_cert = true
+port = "8089"
+test_earliest_time = "-1h@h"
+test_latest_time = "now"
+
+earliest_time = "-1h@h"
+latest_time = "now"
+
+cron_schedule = "0 * * * *"
+
+[platforms.splunk.pipelines.windows_process_creation]
+
+pipelines = ["splunk_windows", "splunk_cim"]
+pipelines_correlation = ["splunk_windows"]
+product = "windows"
+category = "process_creation"
+format = "data_model"
+format_correlation = "default"
+
+[platforms.splunk.savedsearch_parameters]
+
+alert_type = "number of events"
+app = "search"
+sharing = "app"
+alert_comparator = "greater than"
+alert_threshold = 0
+"alert.track" = 1
+allow_skew = "67%"
+"alert.suppress" = 0
+"alert.digest_mode" = 0

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -48,3 +48,24 @@ def test_convert_valid_file_with_customer_filter():
     """Test conversion of valid sigma rule with customer-specific filter applied"""
     result = runner.invoke(app, ["rules", "convert", "--platform", "microsoft_xdr", "--rules", "tests/files/sigma-rules/valid/convert_valid_rule.yml", "--config-file", "tests/files/test_config.toml", "--mssp"])
     assert result.exit_code == 0
+
+def test_file_has_correlation_detects_in_multidoc():
+    """_file_has_correlation must scan every YAML document, not only the first."""
+    from droid.convert import Conversion
+    assert Conversion._file_has_correlation("tests/files/sigma-rules/valid/convert_valid_correlation_rule.yml") is True
+    assert Conversion._file_has_correlation("tests/files/sigma-rules/valid/convert_valid_rule.yml") is False
+
+def test_convert_correlation_rule_with_overrides():
+    """Correlation rule uses format_correlation + pipelines_correlation when set.
+
+    Without the overrides, Splunk data_model output crashes on SigmaCorrelationRule
+    because finalize_query_data_model reads .logsource directly.
+    """
+    result = runner.invoke(app, ["rules", "convert", "--platform", "splunk", "--rules", "tests/files/sigma-rules/valid/convert_valid_correlation_rule.yml", "--config-file", "tests/files/test_config_correlation.toml"])
+    assert result.exit_code == 0
+
+def test_convert_atomic_rule_ignores_correlation_overrides():
+    """Atomic rule in a config that defines correlation overrides still uses the
+    regular `pipelines` + `format` (i.e. the override only fires for correlation rules)."""
+    result = runner.invoke(app, ["rules", "convert", "--platform", "splunk", "--rules", "tests/files/sigma-rules/valid/convert_valid_rule.yml", "--config-file", "tests/files/test_config_correlation.toml"])
+    assert result.exit_code == 0


### PR DESCRIPTION
## Description

Adds two optional fields to `[platforms.<backend>.pipelines.<group>]` so correlation rules can be converted with a different pipeline list and output format than atomic rules in the same logsource group.

- `pipelines_correlation` (array of strings): overrides `pipelines` when the rule file is a correlation rule.
- `format_correlation` (string): overrides `format` when the rule file is a correlation rule.

Both are optional and additive. Configs without them behave exactly as before.

Some backend formats are incompatible with Sigma correlation rules. The driving case is Splunk `data_model`: the backend's `finalize_query_data_model` reads `rule.logsource.product` directly, which crashes on `SigmaCorrelationRule`.

