### PR TITLE
feature(correlation): cover custom field merge for atomic and correlation rules

### DIFF
--- a/src/droid/convert.py
+++ b/src/droid/convert.py
@@ -17,6 +17,7 @@ from droid.integrity import integrity_rule
 from droid.platforms.elastic import ElasticPlatform
 from droid.platforms.registry import get_platform
 from droid.color import ColorLogger
+from droid.rule_loader import load_rule_content
 
 class Conversion:
     """Base class handling the conversion
@@ -247,20 +248,18 @@ class Conversion:
 
 def load_rule(rule_file):
 
-    with open(rule_file, "r", encoding="utf-8") as stream:
-        try:
-            object = list(yaml.safe_load_all(stream))[0]
-            if "fields" in object:
-                object.pop("fields")
-                # Here we remove the fields to avoid Sigma to arbitrary
-                # convert the rule to {{ query }} | table field1,field2
-                # https://github.com/SigmaHQ/pySigma-backend-splunk/issues/27
-            return object
-        except yaml.YAMLError as exc:
-            print(exc)
-            print("Error reading {0}".format(rule_file))
-            error = True
-            return error
+    try:
+        object = load_rule_content(rule_file)
+        if isinstance(object, dict) and "fields" in object:
+            object.pop("fields")
+            # Here we remove the fields to avoid Sigma to arbitrary
+            # convert the rule to {{ query }} | table field1,field2
+            # https://github.com/SigmaHQ/pySigma-backend-splunk/issues/27
+        return object
+    except yaml.YAMLError as exc:
+        print(exc)
+        print("Error reading {0}".format(rule_file))
+        return True
 
 def convert_sigma_rule(rule_file, parameters, logger, sigma_objects, target, platform, error, search_warning, rules, logger_param):
 

--- a/src/droid/export.py
+++ b/src/droid/export.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from rich import print
 from droid.platforms.registry import get_platform
 from droid.color import ColorLogger
+from droid.rule_loader import load_rule_content
 
 def post_rule_content(rule_content):
     """Post-processing of rule content
@@ -22,19 +23,17 @@ def post_rule_content(rule_content):
 
 def load_rule(rule_file):
 
-    with open(rule_file, "r") as stream:
-        try:
-            object = list(yaml.safe_load_all(stream))[0]
-            if "fields" in object:
-                object.pop("fields")
-                # Here we remove the fields to avoid Sigma to arbitrary
-                # convert the rule to {{ query }} | table field1,field2
-            return object
-        except yaml.YAMLError as exc:
-            print(exc)
-            print("Error reading {0}".format(rule_file))
-            error = True
-            return error
+    try:
+        object = load_rule_content(rule_file)
+        if isinstance(object, dict) and "fields" in object:
+            object.pop("fields")
+            # Here we remove the fields to avoid Sigma to arbitrary
+            # convert the rule to {{ query }} | table field1,field2
+        return object
+    except yaml.YAMLError as exc:
+        print(exc)
+        print("Error reading {0}".format(rule_file))
+        return True
 
 def export_rule(
         parameters: dict, rule_content: object, rule_converted: str,

--- a/src/droid/integrity.py
+++ b/src/droid/integrity.py
@@ -12,6 +12,7 @@ from rich import print
 from droid.platforms.registry import get_platform
 from droid.color import ColorLogger
 from droid.export import post_rule_content
+from droid.rule_loader import load_rule_content
 
 if TYPE_CHECKING:
     from droid.platforms.splunk import SplunkPlatform
@@ -21,15 +22,12 @@ if TYPE_CHECKING:
 
 def load_rule(rule_file):
 
-    with open(rule_file, "r") as stream:
-        try:
-            object = list(yaml.safe_load_all(stream))[0]
-            return object
-        except yaml.YAMLError as exc:
-            print(exc)
-            print("Error reading {0}".format(rule_file))
-            error = True
-            return error
+    try:
+        return load_rule_content(rule_file)
+    except yaml.YAMLError as exc:
+        print(exc)
+        print("Error reading {0}".format(rule_file))
+        return True
 
 def check_rule_removed(rule_content, rule_file, saved_search, logger, error):
     is_removed = rule_content.get("custom", {}).get("removed")

--- a/src/droid/list.py
+++ b/src/droid/list.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from rich import print
 from sigma.plugins import InstalledSigmaPlugins
 from droid.color import ColorLogger
+from droid.rule_loader import load_rule_content
 
 def load_rule(parameters, rule_file, logger):
     """Load rule
@@ -17,14 +18,12 @@ def load_rule(parameters, rule_file, logger):
     """
     logger.debug("processing rule {0}".format(rule_file))
 
-    with open(rule_file, 'r') as stream:
-        try:
-            object = list(yaml.safe_load_all(stream))[0]
-            return object
-        except yaml.YAMLError as exc:
-            print(exc)
-            print("Error reading {0}".format(rule_file))
-            error = True
+    try:
+        return load_rule_content(rule_file)
+    except yaml.YAMLError as exc:
+        print(exc)
+        print("Error reading {0}".format(rule_file))
+        return None
 
 
 def list_unique_keys(rule, unique_keys) -> None:

--- a/src/droid/rule_loader.py
+++ b/src/droid/rule_loader.py
@@ -1,0 +1,46 @@
+"""
+Shared helpers for loading Sigma rule YAML files.
+
+Sigma correlation rules are stored as multi-document YAML files: the atomic
+rules come first and the `correlation:` document comes last. Downstream code
+relies on the first (atomic) document for structural fields like `logsource`
+and `detection`, but users naturally put droid-specific overrides on the
+correlation document, e.g.::
+
+    correlation:
+        type: temporal
+        ...
+    custom:
+        ignore_search: True
+
+Without the merge below, `rule_content.get("custom", {})` would always miss
+those overrides on correlation rules.
+"""
+import yaml
+
+
+def load_rule_content(rule_file):
+    """Load a rule file and return its primary content.
+
+    For multi-document correlation files, the `custom` field declared on the
+    correlation document is merged onto the first document so that overrides
+    such as `ignore_search`, `disabled`, `removed`, `ignore_export_error`,
+    Splunk alert keys, etc. apply whether set on the atomic rule or the
+    correlation rule. Correlation-document keys win on conflict.
+    """
+    with open(rule_file, "r", encoding="utf-8") as stream:
+        docs = list(yaml.safe_load_all(stream))
+
+    if not docs:
+        return None
+
+    primary = docs[0]
+    if not isinstance(primary, dict):
+        return primary
+
+    for doc in docs[1:]:
+        if isinstance(doc, dict) and "correlation" in doc and doc.get("custom"):
+            merged = {**(primary.get("custom") or {}), **doc["custom"]}
+            return {**primary, "custom": merged}
+
+    return primary

--- a/src/droid/search.py
+++ b/src/droid/search.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 from rich import print
 from droid.platforms.registry import get_platform
 from droid.color import ColorLogger
+from droid.rule_loader import load_rule_content
 
 if TYPE_CHECKING:
     from droid.platforms.splunk import SplunkPlatform
@@ -20,15 +21,12 @@ if TYPE_CHECKING:
 
 def load_rule(rule_file):
 
-    with open(rule_file, "r") as stream:
-        try:
-            object = list(yaml.safe_load_all(stream))[0]
-            return object
-        except yaml.YAMLError as exc:
-            print(exc)
-            print("Error reading {0}".format(rule_file))
-            error = True
-            return error
+    try:
+        return load_rule_content(rule_file)
+    except yaml.YAMLError as exc:
+        print(exc)
+        print("Error reading {0}".format(rule_file))
+        return True
 
 def search_rule_splunk(rule_converted, platform: SplunkPlatform, rule_file, parameters, logger, error, search_warning):
     try:

--- a/src/droid/validate.py
+++ b/src/droid/validate.py
@@ -11,6 +11,7 @@ from sigma.plugins import InstalledSigmaPlugins
 from sigma.exceptions import SigmaDetectionError
 from sigma.exceptions import SigmaConditionError
 from droid.color import ColorLogger
+from droid.rule_loader import load_rule_content
 
 class SigmaValidation:
 
@@ -90,15 +91,12 @@ def load_rule(parameters, logger, rule_file):
 
     logger.debug("processing rule {0}".format(rule_file), extra={"rule_file": rule_file})
 
-    with open(rule_file, 'r') as stream:
-        try:
-            object = list(yaml.safe_load_all(stream))[0]
-        except yaml.YAMLError as exc:
-            print(exc)
-            print("Error reading {0}".format(rule_file))
-            error = True
-
-    return object
+    try:
+        return load_rule_content(rule_file)
+    except yaml.YAMLError as exc:
+        print(exc)
+        print("Error reading {0}".format(rule_file))
+        return None
 
 def validate_rules(parameters, return_objects, base_config, logger_param) -> None:
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -69,3 +69,197 @@ def test_convert_atomic_rule_ignores_correlation_overrides():
     regular `pipelines` + `format` (i.e. the override only fires for correlation rules)."""
     result = runner.invoke(app, ["rules", "convert", "--platform", "splunk", "--rules", "tests/files/sigma-rules/valid/convert_valid_rule.yml", "--config-file", "tests/files/test_config_correlation.toml"])
     assert result.exit_code == 0
+
+def test_load_rule_merges_custom_from_correlation_document(tmp_path):
+    """`custom` on the correlation document must surface on the loaded rule_content.
+
+    Without the merge, downstream checks like rule_content.get("custom", {}).get("ignore_search")
+    silently miss any override placed on the correlation rule (the last YAML doc),
+    because load_rule used to return only the first document.
+    """
+    from droid.rule_loader import load_rule_content
+
+    rule_file = tmp_path / "correlation_with_custom.yml"
+    rule_file.write_text(
+        "title: Atomic 1\n"
+        "id: 11111111-1111-1111-1111-111111111111\n"
+        "name: atomic_1\n"
+        "logsource: {category: process_creation, product: windows}\n"
+        "detection: {selection: {CommandLine|contains: foo.exe}, condition: selection}\n"
+        "---\n"
+        "title: Correlation\n"
+        "id: 22222222-2222-2222-2222-222222222222\n"
+        "correlation: {type: temporal, rules: [atomic_1], timespan: 10m}\n"
+        "custom:\n"
+        "    ignore_search: true\n"
+        "    disabled: true\n"
+    )
+
+    loaded = load_rule_content(str(rule_file))
+
+    assert loaded["title"] == "Atomic 1"  # structural primary preserved
+    assert loaded["custom"]["ignore_search"] is True
+    assert loaded["custom"]["disabled"] is True
+
+def test_load_rule_correlation_custom_overrides_atomic_custom(tmp_path):
+    """When both atomic and correlation docs declare `custom`, the correlation wins."""
+    from droid.rule_loader import load_rule_content
+
+    rule_file = tmp_path / "both_have_custom.yml"
+    rule_file.write_text(
+        "title: Atomic\n"
+        "id: 11111111-1111-1111-1111-111111111111\n"
+        "name: atomic\n"
+        "logsource: {category: process_creation, product: windows}\n"
+        "detection: {selection: {CommandLine|contains: foo.exe}, condition: selection}\n"
+        "custom:\n"
+        "    ignore_search: false\n"
+        "    earliest_time: -1h\n"
+        "---\n"
+        "title: Correlation\n"
+        "id: 22222222-2222-2222-2222-222222222222\n"
+        "correlation: {type: temporal, rules: [atomic], timespan: 10m}\n"
+        "custom:\n"
+        "    ignore_search: true\n"
+    )
+
+    loaded = load_rule_content(str(rule_file))
+
+    assert loaded["custom"]["ignore_search"] is True   # correlation override wins
+    assert loaded["custom"]["earliest_time"] == "-1h"  # atomic-only key preserved
+
+def test_load_rule_single_document_unchanged(tmp_path):
+    """Single-document rules behave identically to the legacy loader."""
+    from droid.rule_loader import load_rule_content
+
+    rule_file = tmp_path / "single.yml"
+    rule_file.write_text(
+        "title: Solo\n"
+        "id: 11111111-1111-1111-1111-111111111111\n"
+        "logsource: {category: process_creation, product: windows}\n"
+        "detection: {selection: {CommandLine|contains: foo.exe}, condition: selection}\n"
+        "custom: {ignore_search: true}\n"
+    )
+
+    loaded = load_rule_content(str(rule_file))
+
+    assert loaded["title"] == "Solo"
+    assert loaded["custom"] == {"ignore_search": True}
+
+def test_load_rule_custom_on_atomic_only_preserved(tmp_path):
+    """Multi-doc correlation file with `custom` only on the atomic doc keeps it intact."""
+    from droid.rule_loader import load_rule_content
+
+    rule_file = tmp_path / "atomic_only_custom.yml"
+    rule_file.write_text(
+        "title: Atomic\n"
+        "id: 11111111-1111-1111-1111-111111111111\n"
+        "name: atomic\n"
+        "logsource: {category: process_creation, product: windows}\n"
+        "detection: {selection: {CommandLine|contains: foo.exe}, condition: selection}\n"
+        "custom:\n"
+        "    ignore_search: true\n"
+        "    disabled: true\n"
+        "---\n"
+        "title: Correlation\n"
+        "id: 22222222-2222-2222-2222-222222222222\n"
+        "correlation: {type: temporal, rules: [atomic], timespan: 10m}\n"
+    )
+
+    loaded = load_rule_content(str(rule_file))
+
+    assert loaded["custom"] == {"ignore_search": True, "disabled": True}
+
+def test_load_rule_multidoc_without_correlation_uses_first(tmp_path):
+    """If no document is a correlation rule, no merge happens — first-doc behaviour."""
+    from droid.rule_loader import load_rule_content
+
+    rule_file = tmp_path / "two_atomic.yml"
+    rule_file.write_text(
+        "title: Atomic 1\n"
+        "id: 11111111-1111-1111-1111-111111111111\n"
+        "logsource: {category: process_creation, product: windows}\n"
+        "detection: {selection: {CommandLine|contains: foo.exe}, condition: selection}\n"
+        "custom: {ignore_search: true}\n"
+        "---\n"
+        "title: Atomic 2\n"
+        "id: 22222222-2222-2222-2222-222222222222\n"
+        "logsource: {category: process_creation, product: windows}\n"
+        "detection: {selection: {CommandLine|contains: bar.exe}, condition: selection}\n"
+        "custom: {ignore_search: false, disabled: true}\n"
+    )
+
+    loaded = load_rule_content(str(rule_file))
+
+    # Second document is NOT a correlation rule, so its `custom` is ignored.
+    assert loaded["title"] == "Atomic 1"
+    assert loaded["custom"] == {"ignore_search": True}
+
+def test_load_rule_correlation_custom_only_extra_keys_merged(tmp_path):
+    """Correlation `custom` keys are added on top of atomic ones; non-overlapping keys coexist."""
+    from droid.rule_loader import load_rule_content
+
+    rule_file = tmp_path / "merge_disjoint.yml"
+    rule_file.write_text(
+        "title: Atomic\n"
+        "id: 11111111-1111-1111-1111-111111111111\n"
+        "name: atomic\n"
+        "logsource: {category: process_creation, product: windows}\n"
+        "detection: {selection: {CommandLine|contains: foo.exe}, condition: selection}\n"
+        "custom:\n"
+        "    earliest_time: -1h\n"
+        "    latest_time: now\n"
+        "---\n"
+        "title: Correlation\n"
+        "id: 22222222-2222-2222-2222-222222222222\n"
+        "correlation: {type: temporal, rules: [atomic], timespan: 10m}\n"
+        "custom:\n"
+        "    ignore_search: true\n"
+        "    removed: true\n"
+    )
+
+    loaded = load_rule_content(str(rule_file))
+
+    assert loaded["custom"] == {
+        "earliest_time": "-1h",
+        "latest_time": "now",
+        "ignore_search": True,
+        "removed": True,
+    }
+
+def test_search_rule_short_circuits_on_correlation_ignore_search(tmp_path):
+    """End-to-end: `custom.ignore_search` on the correlation doc must skip the search.
+
+    Regression guard for the original bug — before the fix, search would still run
+    against the platform because `rule_content.get("custom", {})` only ever saw the
+    first atomic doc.
+    """
+    from droid.search import load_rule, search_rule
+
+    rule_file = tmp_path / "corr_ignore_search.yml"
+    rule_file.write_text(
+        "title: Atomic\n"
+        "id: 11111111-1111-1111-1111-111111111111\n"
+        "name: atomic\n"
+        "logsource: {category: process_creation, product: windows}\n"
+        "detection: {selection: {CommandLine|contains: foo.exe}, condition: selection}\n"
+        "---\n"
+        "title: Correlation\n"
+        "id: 22222222-2222-2222-2222-222222222222\n"
+        "correlation: {type: temporal, rules: [atomic], timespan: 10m}\n"
+        "custom: {ignore_search: true}\n"
+    )
+
+    rule_content = load_rule(str(rule_file))
+    assert rule_content["custom"]["ignore_search"] is True
+
+    class _Params:
+        platform = "splunk"  # would otherwise try to call splunk
+
+    # platform=None would crash inside search_rule_splunk; the early-return must fire first.
+    error, search_warning = search_rule(
+        _Params(), rule_content, "irrelevant-query", None, str(rule_file),
+        False, False, {"json_enabled": False, "log_file": None},
+    )
+    assert error is False
+    assert search_warning is False


### PR DESCRIPTION
## Description

- Correlation rules are multi-document YAML files (see the `---`) the user-facing rule (and the natural place for a `custom:` block) is the last document. Every `load_rule()` in droid only read the first document, so overrides like `ignore_search`, `disabled`, `removed`, `query_period`, `action.webhook.param.url`, etc. set on the correlation rule were silently ignored.

- New shared `droid.rule_loader.load_rule_content()` keeps the first document as the structural primary (downstream code still needs its `logsource`/`detection`) and merges the `custom` field from the correlation document on top. Correlation-document keys win on conflict.

- All six `load_rule()` functions (convert, search, export, integrity, validate, list) now delegate to the helper, so every backend (Splunk, Sentinel, MS XDR, Elastic) automatically sees the merged `custom`, so no platform-side change needed.