### PR TITLE
feature(correlation): soft-error for non-compatible correlation type + use Sigma metadata from correlation document

### DIFF
--- a/src/droid/convert.py
+++ b/src/droid/convert.py
@@ -11,6 +11,7 @@ from sigma.plugins import InstalledSigmaPlugins
 from sigma.conversion.base import Backend, SigmaCollection
 from sigma.exceptions import SigmaTransformationError
 from sigma.exceptions import SigmaFeatureNotSupportedByBackendError
+from sigma.exceptions import SigmaConversionError
 from droid.search import search_rule
 from droid.export import export_rule
 from droid.integrity import integrity_rule
@@ -439,10 +440,26 @@ def convert_sigma(
         return error, search_warning
 
     except SigmaTransformationError as e:
+        if "not supported by backend" in str(e):
+            logger.warning(f"Backend does not support this correlation type: {rule_file}", extra={"rule_file": rule_file, "error": e, "rule_content": rule_content})
+            error = False
+            return error, search_warning
         logger.error(f"Sigma Transformation error: {rule_file} - error: {e}", extra={"rule_file": rule_file, "error": e, "rule_content": rule_content})
         error = True
         return error, search_warning
+    except SigmaConversionError as e:
+        if "not supported by backend" in str(e):
+            logger.warning(f"Backend does not support this correlation type: {rule_file}", extra={"rule_file": rule_file, "error": e, "rule_content": rule_content})
+            error = False
+            return error, search_warning
+        logger.error(f"Sigma Conversion error: {rule_file} - error: {e}", extra={"rule_file": rule_file, "error": e, "rule_content": rule_content})
+        error = True
+        return error, search_warning
     except NotImplementedError as e:
+        if "not supported by backend" in str(e):
+            logger.warning(f"Backend does not support this correlation type: {rule_file}", extra={"rule_file": rule_file, "error": e, "rule_content": rule_content})
+            error = False
+            return error, search_warning
         logger.error(f"Sigma Transformation error: {rule_file} - error: {e}", extra={"rule_file": rule_file, "error": e, "rule_content": rule_content})
         error = True
         return error, search_warning

--- a/src/droid/rule_loader.py
+++ b/src/droid/rule_loader.py
@@ -1,32 +1,13 @@
-"""
-Shared helpers for loading Sigma rule YAML files.
-
-Sigma correlation rules are stored as multi-document YAML files: the atomic
-rules come first and the `correlation:` document comes last. Downstream code
-relies on the first (atomic) document for structural fields like `logsource`
-and `detection`, but users naturally put droid-specific overrides on the
-correlation document, e.g.::
-
-    correlation:
-        type: temporal
-        ...
-    custom:
-        ignore_search: True
-
-Without the merge below, `rule_content.get("custom", {})` would always miss
-those overrides on correlation rules.
-"""
+"""Helpers for loading Sigma rule YAML files."""
 import yaml
 
 
 def load_rule_content(rule_file):
     """Load a rule file and return its primary content.
 
-    For multi-document correlation files, the `custom` field declared on the
-    correlation document is merged onto the first document so that overrides
-    such as `ignore_search`, `disabled`, `removed`, `ignore_export_error`,
-    Splunk alert keys, etc. apply whether set on the atomic rule or the
-    correlation rule. Correlation-document keys win on conflict.
+    For multi-doc correlation files, correlation-doc fields overlay the
+    atomic doc so identity (title, id, level, …) comes from the correlation
+    rule. `custom` is deep-merged; correlation wins on conflict.
     """
     with open(rule_file, "r", encoding="utf-8") as stream:
         docs = list(yaml.safe_load_all(stream))
@@ -38,9 +19,15 @@ def load_rule_content(rule_file):
     if not isinstance(primary, dict):
         return primary
 
-    for doc in docs[1:]:
-        if isinstance(doc, dict) and "correlation" in doc and doc.get("custom"):
-            merged = {**(primary.get("custom") or {}), **doc["custom"]}
-            return {**primary, "custom": merged}
+    correlation_doc = next(
+        (doc for doc in docs[1:] if isinstance(doc, dict) and "correlation" in doc),
+        None,
+    )
+    if correlation_doc is None:
+        return primary
 
-    return primary
+    merged = {**primary, **correlation_doc}
+    if primary.get("custom") and correlation_doc.get("custom"):
+        merged["custom"] = {**primary["custom"], **correlation_doc["custom"]}
+
+    return merged

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -97,9 +97,108 @@ def test_load_rule_merges_custom_from_correlation_document(tmp_path):
 
     loaded = load_rule_content(str(rule_file))
 
-    assert loaded["title"] == "Atomic 1"  # structural primary preserved
+    assert loaded["title"] == "Correlation"  # correlation identity wins
+    assert loaded["id"] == "22222222-2222-2222-2222-222222222222"
+    assert loaded["name"] == "atomic_1"  # structural field stays from atomic
+    assert loaded["logsource"] == {"category": "process_creation", "product": "windows"}
     assert loaded["custom"]["ignore_search"] is True
     assert loaded["custom"]["disabled"] is True
+
+
+def test_load_rule_correlation_metadata_overrides_atomic(tmp_path):
+    """Metadata fields surfaced to the target platform (title, description, level,
+    date, modified, author, tags, status, references, falsepositives) must come
+    from the correlation document so Sentinel/XDR/Splunk show the correlation
+    rule's identity, not the first atomic rule's.
+    """
+    import datetime
+
+    from droid.rule_loader import load_rule_content
+
+    rule_file = tmp_path / "correlation_metadata.yml"
+    rule_file.write_text(
+        "title: Atomic 1\n"
+        "id: 11111111-1111-1111-1111-111111111111\n"
+        "name: atomic_1\n"
+        "status: stable\n"
+        "description: Atomic rule referenced by the correlation.\n"
+        "author: alice\n"
+        "date: 2024-01-01\n"
+        "modified: 2024-06-01\n"
+        "level: low\n"
+        "tags: [attack.execution]\n"
+        "references: [https://example.com/atomic]\n"
+        "falsepositives: [Atomic noise]\n"
+        "logsource: {category: process_creation, product: windows}\n"
+        "detection: {selection: {CommandLine|contains: foo.exe}, condition: selection}\n"
+        "---\n"
+        "title: Convert Temporal Correlation Test\n"
+        "id: 33333333-3333-3333-3333-333333333333\n"
+        "status: test\n"
+        "description: Temporal correlation over the two atomic rules above.\n"
+        "author: pizza53\n"
+        "date: 2026-06-02\n"
+        "modified: 2026-06-10\n"
+        "level: high\n"
+        "tags: [attack.lateral_movement]\n"
+        "references: [https://example.com/correlation]\n"
+        "falsepositives: [Correlation noise]\n"
+        "correlation: {type: temporal, rules: [atomic_1], timespan: 10m}\n"
+    )
+
+    loaded = load_rule_content(str(rule_file))
+
+    assert loaded["title"] == "Convert Temporal Correlation Test"
+    assert loaded["id"] == "33333333-3333-3333-3333-333333333333"
+    assert loaded["status"] == "test"
+    assert loaded["description"] == "Temporal correlation over the two atomic rules above."
+    assert loaded["author"] == "pizza53"
+    assert loaded["date"] == datetime.date(2026, 6, 2)
+    assert loaded["modified"] == datetime.date(2026, 6, 10)
+    assert loaded["level"] == "high"
+    assert loaded["tags"] == ["attack.lateral_movement"]
+    assert loaded["references"] == ["https://example.com/correlation"]
+    assert loaded["falsepositives"] == ["Correlation noise"]
+    # Structural fields stay from the atomic doc so pipelines + backend still work.
+    assert loaded["name"] == "atomic_1"
+    assert loaded["logsource"] == {"category": "process_creation", "product": "windows"}
+    assert loaded["detection"] == {
+        "selection": {"CommandLine|contains": "foo.exe"},
+        "condition": "selection",
+    }
+
+
+def test_load_rule_atomic_metadata_kept_when_correlation_omits_it(tmp_path):
+    """Fields the correlation document doesn't declare fall back to the atomic doc.
+
+    Lets users keep e.g. `tags` on the atomic rule and only declare new metadata on
+    the correlation rule when they want to override it.
+    """
+    from droid.rule_loader import load_rule_content
+
+    rule_file = tmp_path / "partial_metadata.yml"
+    rule_file.write_text(
+        "title: Atomic\n"
+        "id: 11111111-1111-1111-1111-111111111111\n"
+        "name: atomic\n"
+        "author: alice\n"
+        "tags: [attack.execution]\n"
+        "logsource: {category: process_creation, product: windows}\n"
+        "detection: {selection: {CommandLine|contains: foo.exe}, condition: selection}\n"
+        "---\n"
+        "title: Correlation\n"
+        "id: 22222222-2222-2222-2222-222222222222\n"
+        "level: high\n"
+        "correlation: {type: temporal, rules: [atomic], timespan: 10m}\n"
+    )
+
+    loaded = load_rule_content(str(rule_file))
+
+    assert loaded["title"] == "Correlation"
+    assert loaded["level"] == "high"
+    # Correlation didn't declare these — atomic values flow through.
+    assert loaded["author"] == "alice"
+    assert loaded["tags"] == ["attack.execution"]
 
 def test_load_rule_correlation_custom_overrides_atomic_custom(tmp_path):
     """When both atomic and correlation docs declare `custom`, the correlation wins."""


### PR DESCRIPTION
## Description

- Multi-doc correlation files now Sigma metadata from the correlation document instead of the first atomic rule

- Backend "not supported" responses for correlation types are downgraded from errors to warnings across `SigmaTransformationError`, `SigmaConversionError`, and `NotImplementedError`, so a single unsupported correlation type no longer fails the whole convert run.
